### PR TITLE
HICAT-651 Report exposure status when exposure raises an exception

### DIFF
--- a/catkit/hardware/zwo/ZwoCamera.py
+++ b/catkit/hardware/zwo/ZwoCamera.py
@@ -83,8 +83,12 @@ class ZwoCamera(Camera):
 
         # Passing the initial_sleep and poll values prevent crashes. DO NOT REMOVE!!!
         poll = quantity(0.1, units.second)
-        image = self.camera.capture(initial_sleep=exposure_time.to(units.second).magnitude, poll=poll.magnitude)
-
+        try:
+            image = self.camera.capture(initial_sleep=exposure_time.to(units.second).magnitude, poll=poll.magnitude)
+        except zwoasi.ZWO_CaptureError as error:
+            # Maps to:
+            # https://github.com/stevemarple/python-zwoasi/blob/1aadf7924dd1cb3b8587d97689d82cd5f1a0b5f6/zwoasi/__init__.py#L889-L893
+            raise RuntimeError(f"Exposure status: {error.exposure_status}") from error
         return image.astype(np.dtype(np.int))
 
     def capture_and_orient(self, exposure_time, theta, fliplr):


### PR DESCRIPTION
Resolves HICAT-651

The reported status maps to the following semantics ([src](https://github.com/stevemarple/python-zwoasi/blob/1aadf7924dd1cb3b8587d97689d82cd5f1a0b5f6/zwoasi/__init__.py#L889-L893)).
```python
# ASI_EXPOSURE_STATUS
ASI_EXP_IDLE = 0
ASI_EXP_WORKING = 1
ASI_EXP_SUCCESS = 2
ASI_EXP_FAILED = 3
```

Signed-off-by: James Noss <jnoss@stsci.edu>