### PR TITLE
HICAT-612 Load catkit.hardware.testbed_state from downstream package

### DIFF
--- a/catkit/catkit_types.py
+++ b/catkit/catkit_types.py
@@ -53,3 +53,28 @@ SinSpecification = namedtuple("SinSpecification", "angle, ncycles, peak_to_valle
 # Create shortcuts for using Pint globally.
 units = UnitRegistry()
 quantity = units.Quantity
+
+
+class Pointer:
+    def __init__(self, ref):
+        super().__getattribute__("point_to")(ref)
+
+    def __getattribute__(self, name):
+        if name == "self":
+            return super().__getattribute__("ref")
+        elif name == "point_to":
+            return super().__getattribute__(name)
+        else:
+            return super().__getattribute__("ref").__getattribute__(name)
+
+    def __setattr__(self, name, value):
+        super().__getattribute__("ref").__setattr__(name, value)
+
+    def __delattr__(self, name):
+        super().__getattribute__("ref").__delattr__(name)
+
+    def __dir__(self, name):
+        super().__getattribute__("ref").__dir__(name)
+
+    def point_to(self, ref):
+        super().__setattr__("ref", ref)

--- a/catkit/emulators/tests/test_emulated_boston_dm.py
+++ b/catkit/emulators/tests/test_emulated_boston_dm.py
@@ -1,5 +1,7 @@
 import os
 import functools
+import sys
+from types import ModuleType
 
 import astropy.units
 import numpy as np
@@ -8,8 +10,23 @@ import pytest
 from catkit.hardware.boston.DmCommand import DmCommand, get_m_per_volt_map
 import catkit.emulators.boston_dm
 import catkit.util
+import catkit.hardware
 
 data_dir = os.path.join(os.path.dirname(__file__), "data")
+
+
+@pytest.fixture(autouse=True)
+def dummy_testbed_state():
+    # Create dummy testbed_state module
+    dummy_testbed_state_module = ModuleType("dummy_testbed_state")
+    # Add the required attributes needed for the subsequent tests
+    dummy_testbed_state_module.dm1_command_object = None
+    dummy_testbed_state_module.dm2_command_object = None
+    # Add it to the module cache
+    if dummy_testbed_state_module.__name__ not in sys.modules:
+        sys.modules[dummy_testbed_state_module.__name__] = dummy_testbed_state_module
+    # Load/assign it to catkit.hardware.testbed_state
+    catkit.hardware.load_testbed_state(dummy_testbed_state_module)
 
 
 class TestPoppyBostonDMController:

--- a/catkit/hardware/__init__.py
+++ b/catkit/hardware/__init__.py
@@ -1,0 +1,13 @@
+import importlib
+
+from catkit.catkit_types import Pointer
+
+testbed_state = Pointer(None)
+
+
+def load_testbed_state(module_to_load):
+    global testbed_state
+
+    testbed_state_to_load = importlib.import_module(module_to_load) if isinstance(module_to_load, str) else module_to_load
+    testbed_state.point_to(testbed_state_to_load)
+    print(f"'catkit.hardware.testbed_state' now points to '{module_to_load}'")

--- a/catkit/hardware/boston/BostonDmController.py
+++ b/catkit/hardware/boston/BostonDmController.py
@@ -1,6 +1,6 @@
 import numpy as np
-from hicat.hardware import testbed_state
 
+from catkit.hardware import testbed_state
 from catkit.interfaces.DeformableMirrorController import DeformableMirrorController
 
 # BMC is Boston's library and it only works on windows.

--- a/catkit/hardware/newport/NewportMotorController.py
+++ b/catkit/hardware/newport/NewportMotorController.py
@@ -2,7 +2,7 @@ import numpy as np
 import logging
 
 from hicat.config import CONFIG_INI
-from hicat.hardware import testbed_state
+from catkit.hardware import testbed_state
 from catkit.interfaces.MotorController import MotorController
 from catkit.hardware.newport.lib import XPS_Q8_drivers
 

--- a/catkit/hardware/sbig/SbigCamera.py
+++ b/catkit/hardware/sbig/SbigCamera.py
@@ -1,9 +1,9 @@
-from hicat.hardware.testbed_state import MetaDataEntry
+from catkit.catkit_types import MetaDataEntry
 from catkit.interfaces.Camera import Camera
 from hicat.config import CONFIG_INI
 from catkit.catkit_types import units, quantity
 import catkit.util
-from hicat.hardware import testbed_state
+from catkit.hardware import testbed_state
 from astropy.io import fits
 from time import sleep
 import numpy as np

--- a/catkit/hardware/tests/test_testbed_state.py
+++ b/catkit/hardware/tests/test_testbed_state.py
@@ -1,0 +1,50 @@
+import sys
+from types import ModuleType
+
+import pytest
+
+
+@pytest.fixture(scope="function")
+def fake_testbed_state():
+    dummy_testbed_state_module = ModuleType("dummy_testbed_state")
+    dummy_testbed_state_module.dm1_command_object = 1
+
+    sys.modules[dummy_testbed_state_module.__name__] = dummy_testbed_state_module
+    return dummy_testbed_state_module
+
+
+def test_import(fake_testbed_state):
+    import catkit.hardware
+    catkit.hardware.load_testbed_state(fake_testbed_state)
+    assert catkit.hardware.testbed_state.dm1_command_object == 1
+
+
+def test_from_import(fake_testbed_state):
+    from catkit.hardware import testbed_state, load_testbed_state
+    load_testbed_state(fake_testbed_state)
+    assert testbed_state.dm1_command_object == 1
+
+
+def test_identitiy(fake_testbed_state):
+    import catkit.hardware
+    catkit.hardware.load_testbed_state(fake_testbed_state)
+    assert catkit.hardware.testbed_state.self is fake_testbed_state
+
+
+def test_attribute_identity(fake_testbed_state):
+    import catkit.hardware
+    catkit.hardware.load_testbed_state(fake_testbed_state)
+
+    catkit.hardware.testbed_state.ref = {}
+    assert fake_testbed_state.ref is catkit.hardware.testbed_state.ref
+
+
+def test_two_way_access(fake_testbed_state):
+    import catkit.hardware
+    catkit.hardware.load_testbed_state(fake_testbed_state)
+
+    fake_testbed_state.dm1_command_object = 3
+    assert catkit.hardware.testbed_state.dm1_command_object == 3
+
+    catkit.hardware.testbed_state.dm1_command_object = 4
+    assert fake_testbed_state.dm1_command_object == 4

--- a/catkit/hardware/thorlabs/ThorlabsFW102C.py
+++ b/catkit/hardware/thorlabs/ThorlabsFW102C.py
@@ -5,7 +5,7 @@ from hicat.config import CONFIG_INI
 from pyvisa import constants
 import time
 
-from hicat.hardware import testbed_state
+from catkit.hardware import testbed_state
 from catkit.interfaces.FilterWheel import FilterWheel
 
 

--- a/catkit/hardware/thorlabs/ThorlabsMCLS1.py
+++ b/catkit/hardware/thorlabs/ThorlabsMCLS1.py
@@ -6,7 +6,7 @@ import time
 
 from catkit.interfaces.LaserSource import LaserSource
 from hicat.config import CONFIG_INI
-from hicat.hardware import testbed_state
+from catkit.hardware import testbed_state
 
 """Interface for a laser source."""
 

--- a/catkit/hardware/thorlabs/ThorlabsMFF101.py
+++ b/catkit/hardware/thorlabs/ThorlabsMFF101.py
@@ -7,7 +7,7 @@ import time
 import logging
 from catkit.interfaces.FlipMotor import FlipMotor
 from hicat.config import CONFIG_INI
-from hicat.hardware import testbed_state
+from catkit.hardware import testbed_state
 
 """Implementation of the FlipMotor interface for the Thorlabs MFF101 Flip Mount."""
 

--- a/catkit/hardware/zwo/ZwoCamera.py
+++ b/catkit/hardware/zwo/ZwoCamera.py
@@ -9,7 +9,7 @@ from catkit.catkit_types import MetaDataEntry, units, quantity
 from catkit.interfaces.Camera import Camera
 from hicat.config import CONFIG_INI
 import catkit.util
-from hicat.hardware import testbed_state
+from catkit.hardware import testbed_state
 
 
 """Implementation of Hicat.Camera ABC that provides interface and context manager for using ZWO cameras."""


### PR DESCRIPTION
Resolves HICAT-612

See https://github.com/spacetelescope/hicat-package/pull/169 for load implementation from hicat.

Signed-off-by: James Noss <jnoss@stsci.edu>