### PR TITLE
Quick / vital fix was to constrain all differences. Really we only need pint to be constrained.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,8 @@
 
 name: catkit
 dependencies:
-  - astropy=3.2.3
-  - numpy=1.17.4
+  - astropy>=1.3
+  - numpy>=1.15.0
   - pillow>=4.0.0
   - conda-forge::pint<=0.9.0
   - conda-forge::pyusb


### PR DESCRIPTION
Now that I've had a minute I have had a minute to test carefully, this is the least amount we *need* to change for our environment update. This is the more complete solution that was started with https://github.com/spacetelescope/instrument-interface-library/pull/59