### PR TITLE
Updating setup.py for a new 0.5.2 catkit release.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='catkit',
-      version='0.5.1',
+      version='0.5.2',
       description='Python API wrapping hardware and device drivers for the Optics Lab.',
       url='https://github.com/spacetelescope/instrument-interface-library',
       author='Makidon Optics Lab',


### PR DESCRIPTION
This is a PR for a 0.5.2 release. 

Given the pretty rapid development in the last few weeks I think it's time for a new release. 
This will also let us straighten out our version references in our CI on the hicat side. 