### PR TITLE
HICAT-702 write simulated npoint (+refactor)

### DIFF
--- a/catkit/emulators/npoint_tiptilt.py
+++ b/catkit/emulators/npoint_tiptilt.py
@@ -35,7 +35,7 @@ class PyusbNpointEmulator():
         will get send in fake hex messages. """
 
         self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__qualname__}")
-        self.dummy_values = {'{}'.format(n): {'loop':0, 'p_gain':0, 'i_gain':0, 'd_gain':0} for n in (1, 2)}
+        self.dummy_values = {f'{n}': {'loop':0, 'p_gain':0, 'i_gain':0, 'd_gain':0} for n in (1, 2)}
         self.expected_response = None
         self.last_message = None
         self.second_to_last_message = None
@@ -93,7 +93,7 @@ class PyusbNpointEmulator():
             key = hex(addr[1])[3] + hex(addr[0])[2:]
             channel = hex(addr[1])[2]
             self.dummy_values[channel][cmd_dict[key]] = val
-            self.log.info('Setting channel {} key {} to {}'.format(channel, cmd_dict[key], val))
+            self.log.info(f'Setting channel {channel} key {cmd_dict[key]} to {val}')
         
         elif message[0] == 162:
 
@@ -109,7 +109,7 @@ class PyusbNpointEmulator():
                 val = struct.unpack('<I', val)[0]
                 
                 self.dummy_values[channel]['loop'] = val
-                self.log.info('Setting channel {} key {} to {}'.format(channel, cmd_dict[key], val))
+                self.log.info(f'Setting channel {channel} key {cmd_dict[key]} to {val}')
                 
                 full_address = [message[n] for n in range(1,5)]
                 full_val = [message[n] for n in (5,len(message)-1)]

--- a/catkit/emulators/npoint_tiptilt.py
+++ b/catkit/emulators/npoint_tiptilt.py
@@ -1,5 +1,4 @@
-"""
-Interface for the nPoint Tip/Tilt close loop controller. 
+""" Interface for the nPoint Tip/Tilt close loop controller. 
 Connects to the controller via usb, and then sends and recieves hex
 messages to send commands, check the status, and put error handling over
 top. 
@@ -63,8 +62,7 @@ class PyusbNpointEmulator:
         simulation, no behavior necesarry."""
         
         if configuration is not None:
-            raise NotImplementedError("We don't have the ability to set or simulate non-default configuration."
-        
+            raise NotImplementedError("We don't have the ability to set or simulate non-default configuration.")
         pass
     
     def read(self, endpoint, message_length, timeout):
@@ -73,12 +71,13 @@ class PyusbNpointEmulator:
        
         return self.expected_response
 
+
     def write(self, endpoint, message, timeout):
         """ On hardware, writes a single message from device. In simulation,
         updates dummy values. """
         
         # Create a reverse version of the command dictionary
-        self.cmd_dict = {'084': 'loop', '720': 'p_gain', '728':  'i_gain', '730': 'd_gain'}
+        cmd_dict = {'084': 'loop', '720': 'p_gain', '728':  'i_gain', '730': 'd_gain'}
         
         # Set last and second to last messages
         self.second_to_last_message = self.last_message

--- a/catkit/emulators/npoint_tiptilt.py
+++ b/catkit/emulators/npoint_tiptilt.py
@@ -5,6 +5,7 @@ top.
 """
 
 import logging
+import os
 import struct
 
 from catkit.hardware.npoint.nPointTipTiltController import Commands, Parameters, NPointTipTiltController
@@ -112,3 +113,10 @@ class SimNPointTipTiltController(SimInstrument, NPointTipTiltController):
 
     instrument_lib = PyusbNpointEmulator
     library_mapping = {'libusb0': EmulatedLibUSB, 'libusb1': EmulatedLibUSB}
+
+    def initialize(self, vendor_id, product_id, library_path=None, library='libusb0', timeout=60):
+        return super().initialize(vendor_id=vendor_id,
+                                  product_id=product_id,
+                                  library_path=os.path.abspath(__file__),
+                                  library=library,
+                                  timeout=timeout)

--- a/catkit/emulators/npoint_tiptilt.py
+++ b/catkit/emulators/npoint_tiptilt.py
@@ -1,0 +1,105 @@
+"""
+Interface for the nPoint Tip/Tilt close loop controller. 
+Connects to the controller via usb, and then sends and recieves hex
+messages to send commands, check the status, and put error handling over
+top. 
+"""
+
+## -- IMPORTS
+
+import configparser
+import datetime
+import functools
+import logging
+import os
+import struct
+import warnings
+
+from numpy import double
+
+
+
+## -- FUNCTIONS and FIDDLING 
+
+class PyusbNpointEmulator():
+    """nPointTipTilt connection class. 
+
+    This nPointTipTilt class acts as a useful connection and storage vehicle 
+    for commands sent to the nPoint FTID LC400 controller. It has built in 
+    functions that allow for writing commands, checking the status, etc. 
+    By instantiating the nPointTipTilt object you find the LC400 controller 
+    and set the default configuration. Memory managers in the back end 
+    should close the connection when the time is right.
+    """
+
+    def __init__(self):
+        """ Since we'll need to respond as if commands are being sent and we
+        can read values, this is where we'll initialize some dummy values that
+        will get send in fake hex messages. """
+
+        self.dummy_values = {'{}'.format(n): {'loop':0, 'p_gain':0, 'i_gain':0,
+            'd_gain':0} for n in ('1', '2')}
+        self.expected_response = ''
+
+    def find(self, vendor_id, product_id):
+        """ On hardware, locates device. In simulation, returns itself so we
+        can keep going."""
+
+        self.logger.info('SIMULATED nPointTipTilt instantiated and logging online.')
+        
+        return self
+
+    def __iter__(self):
+        """ Simulated iteration to appeal to the ability to check the
+        configuration modes with ``get_config``. """
+
+        for cfg in ['< SIMULATED CONFIGUARTION 1: 0 mA>']:
+            yield cfg
+    
+    def set_configuration():
+        """ On hardware, sets nPoint to its defaul configuration. In
+        simulation, no behavior necesarry."""
+        pass
+    
+    def read(self, endpoint, message_length, timeout):
+        """ On hardware, reads single message from device. In simulation, pulls
+        most recent message that expected a response. """
+       
+        return self.expected_response
+
+    def write(self, endpoint, message, timeout):
+        """ On hardware, writes a single message from device. In simulation,
+        updates dummy values. """
+        
+        cmd_dict = {'084': 'loop', '720': 'p_gain', '728': 'i_gain', '730': 'd_gain'}
+
+        # Do some backwards message parsing
+        # Make them into strings of the numbers that map to command key and channel
+        address = str(message[2:4]).split('\\x')
+        channel = address[1][0]
+        cmd_val = addres[1][1] + addres[2][:-1]
+        cmd_key = cmd_dict[cmd_val] 
+        
+        if message[0] == 164:
+            # This is get message and we want a response
+            self.logger.info('Simulated response will not pass value check.')
+            self.logger.info('The stored value for {} is {}'.format(cmd_key,
+                self.dummy_values[channel][cmd_key]))
+            expected_response = struct.pack('<Q', int(b'0x0000000000000000', 16))
+            self.expected_response = expected_response
+        elif message[1] == 162:
+            # This is a set message and the message isn't spoofed well enough
+            # for now.
+            pass
+
+        else:
+            raise NotImplementedError('Not implemented message sent to nPoint
+            simulator.')
+
+
+class SimnPointTipTiltController(SimInstrument, nPointTipTiltController):
+    """ Emulated version of the nPoint tip tilt controller. 
+    Directly follows the npoint, except points to simlated USB connection
+    library. """
+
+    instrument_lib = PyusbNpointEmulator

--- a/catkit/emulators/npoint_tiptilt.py
+++ b/catkit/emulators/npoint_tiptilt.py
@@ -141,7 +141,7 @@ class PyusbNpointEmulator:
             self.expected_response = np.array(full_message, dtype='B')
             
         else:
-            raise NotImplementedError('Not implemented command message sent to nPoint simulator.')
+            raise NotImplementedError('Non implemented command message sent to nPoint simulator.')
 
 
 class SimnPointTipTiltController(SimInstrument, nPointTipTiltController):

--- a/catkit/emulators/npoint_tiptilt.py
+++ b/catkit/emulators/npoint_tiptilt.py
@@ -14,6 +14,12 @@ from catkit.hardware.npoint.nPointTipTiltController import Commands, Variables, 
 from catkit.interfaces.Instrument import SimInstrument
 
 
+class EmulatedLibUSB:
+    @staticmethod
+    def get_backend(find_library=None):
+        pass
+
+
 class PyusbNpointEmulator:
     """nPointTipTilt connection class. 
 
@@ -134,3 +140,4 @@ class SimnPointTipTiltController(SimInstrument, nPointTipTiltController):
     library. """
 
     instrument_lib = PyusbNpointEmulator
+    library_mapping = {'libusb0': EmulatedLibUSB, 'libusb1': EmulatedLibUSB}

--- a/catkit/emulators/npoint_tiptilt.py
+++ b/catkit/emulators/npoint_tiptilt.py
@@ -1,21 +1,18 @@
-""" Interface for the nPoint Tip/Tilt close loop controller. 
+""" Interface for the nPoint Tip/Tilt closed-loop controller.
 Connects to the controller via usb, and then sends and recieves hex
 messages to send commands, check the status, and put error handling over
-top. 
+top.
 """
 
-## -- IMPORTS
-
+from collections import deque
 import logging
 import struct
 
 import numpy as np
 
-from catkit.hardware.npoint.nPointTipTiltController import nPointTipTiltController
+from catkit.hardware.npoint.nPointTipTiltController import Commands, Variables, nPointTipTiltController
 from catkit.interfaces.Instrument import SimInstrument
 
-
-## -- FUNCTIONS and FIDDLING 
 
 class PyusbNpointEmulator:
     """nPointTipTilt connection class. 
@@ -28,79 +25,67 @@ class PyusbNpointEmulator:
     should close the connection when the time is right.
     """
 
+    config_params = ('< SIMULATED CONFIGUARTION 1: 0 mA>',)
+    # Create a reverse version of the command dictionary
+    message_prefix = (50, 96, 164)
+    message_suffix = (85,)
+    channels = (1, 2)
+
     def __init__(self):
         """ Since we'll need to respond as if commands are being sent and we
-        can read values, this is where we'll initialize some dummy values that
-        will get send in fake hex messages. """
+        can read values, this is where we'll initialize some value stores that
+        will get sent in emulated messages. """
 
         self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__qualname__}")
-        self.dummy_values = {f'{n}': {'loop':0, 'p_gain':0, 'i_gain':0, 'd_gain':0} for n in (1, 2)}
-        self.commands = {'get': 164, 'set': 162, 'second_msg': 163}
-        
-        self.expected_response = None
-        self.last_message = None
-        self.second_to_last_message = None
-        self.first_half_float = None
-        self.second_half_float = None
+
+        self.value_store = {f'{n}': {var: 0 for var in Variables} for n in self.channels}
+        self.response_message = None
+        self.message_stack = deque([])
+        self.float_message_store = []
 
     def find(self, idVendor, idProduct):
-        """ On hardware, locates device. In simulation, returns itself so we
-        can keep going."""
-
+        """ On hardware, locates device. In simulation, returns itself so we can keep going."""
         self.log.info('SIMULATED nPointTipTilt instantiated and logging online.')
         return self
 
     def __iter__(self):
-        """ Simulated iteration to appeal to the ability to check the
-        configuration modes with ``get_config``. """
-
-        for cfg in ['< SIMULATED CONFIGUARTION 1: 0 mA>']:
+        """ Simulated iteration to appeal to the ability to check the configuration modes with `get_config`. """
+        for cfg in self.config_params:
             yield cfg
     
     def set_configuration(self, configuration=None):
-        """ On hardware, sets nPoint to its defaul configuration. In
-        simulation, no behavior necesarry."""
-        
+        """ On hardware, sets nPoint to its default configuration. In simulation, no behavior necessary."""
         if configuration is not None:
             raise NotImplementedError("We don't have the ability to set or simulate non-default configuration.")
-        pass
-    
-    def read(self, endpoint, message_length, timeout):
-        """ On hardware, reads single message from device. In simulation, pulls
-        most recent message that expected a response. """
-       
-        return self.expected_response
 
+    def read(self, endpoint, message_length, timeout):
+        """ On hardware, reads single message from device. In simulation, pulls most recent message that expected a response. """
+        return self.response_message
 
     def write(self, endpoint, message, timeout):
         """ On hardware, writes a single message from device. In simulation,
-        updates dummy values. """
+        updates logical stored values. """
+
+        self.message_stack.append(message)
         
-        # Create a reverse version of the command dictionary
-        cmd_dict = {'084': 'loop', '720': 'p_gain', '728':  'i_gain', '730': 'd_gain'}
-        
-        # Set last and second to last messages
-        self.second_to_last_message = self.last_message
-        self.last_message = message
-        
-        if message[0] == self.commands['second_msg']:
+        if Commands(message[0]) is Commands.SECOND_MSG:
             
             # This is the second half of a set message for float values.
             # This means there won't be an address to parse
-            self.second_half_float = message[1:-1]
-            float_message = self.first_half_float + self.second_half_float
+            self.float_message_store[1] = message[1:-1]
+            float_message = ''.join(self.float_message_store)
             val = struct.unpack('<d', float_message)[0]
 
-            addr = self.second_to_last_message[1:3]
+            addr = self.message_stack.popleft()[1:3]
             # Pull a channel and key of the style ['0xnm_1', '0xm_2m_3']
             # Where n is the channel 
             # And m_1m_2m_3 make up a key
             key = hex(addr[1])[3] + hex(addr[0])[2:]
             channel = hex(addr[1])[2]
-            self.dummy_values[channel][cmd_dict[key]] = val
-            self.log.info(f'Setting channel {channel} key {cmd_dict[key]} to {val}')
+            self.value_store[channel][Variables(key)] = val
+            self.log.info(f'Setting channel {channel} key {Variables(key)} to {val}')
         
-        elif message[0] == self.commands['set']:
+        elif Commands(message[0]) is Commands.SET:
 
             # This is an int set or the first half of a float set
             addr = message[1:3]
@@ -108,26 +93,25 @@ class PyusbNpointEmulator:
             key = hex(addr[1])[3] + hex(addr[0])[2:]
             channel = hex(addr[1])[2]
 
-            if key == '084':
+            if Variables(key) is Variables.LOOP:
                 # int set for open/close loop
                 val = message[-5:-1]
                 val = struct.unpack('<I', val)[0]
                 
-                self.dummy_values[channel]['loop'] = val
-                self.log.info(f'Setting channel {channel} key {cmd_dict[key]} to {val}')
+                self.value_store[channel][Variables.LOOP] = val
+                self.log.info(f'Setting channel {channel} key {Variables(key)} to {val}')
                 
             else:
                 # float set for gain
-                self.first_half_float = message[-5:-1]
+                self.float_message_store[0] = message[-5:-1]
 
-        
-        elif message[0] == self.commands['get']:
+        elif Commands(message[0]) is Commands.GET:
             # This is get message and we want a response
             addr = message[1:3]
-            cmd_key = cmd_dict[hex(addr[1])[3] + hex(addr[0])[2:]]
+            cmd_key = Variables((addr[1])[3] + hex(addr[0])[2:])
             channel = hex(addr[1])[2]
-            val = self.dummy_values[channel][cmd_key]
-            if cmd_key == 'loop':
+            val = self.value_store[channel][cmd_key]
+            if cmd_key is Variables.LOOP:
                 # pack as an int and pad with zeros
                 hex_val = struct.pack('<I', val)
                 full_val = [hex_val[n] for n in range(len(hex_val))] + [0, 0, 0, 0]
@@ -137,8 +121,8 @@ class PyusbNpointEmulator:
                 full_val = [hex_val[n] for n in range(len(hex_val))]
             
             full_address = [message[n] for n in range(1,5)]
-            full_message = [50, 96, 164] + full_address + full_val + [85]
-            self.expected_response = np.array(full_message, dtype='B')
+            full_message = self.message_prefix + full_address + full_val + self.message_suffix
+            self.response_message = np.array(full_message, dtype='B')
             
         else:
             raise NotImplementedError('Non implemented command message sent to nPoint simulator.')

--- a/catkit/emulators/tests/test_npoint_tiptilt.py
+++ b/catkit/emulators/tests/test_npoint_tiptilt.py
@@ -1,0 +1,13 @@
+import os
+
+from catkit.emulators.npoint_tiptilt import SimnPointTipTiltController
+
+vendor_id = 1027
+product_id = 24596
+
+
+def test_init():
+    SimnPointTipTiltController(config_id="npoint_tiptilt_lc_400",
+                               vendor_id=vendor_id,
+                               product_id=product_id,
+                               library_path=os.path.abspath(__file__))

--- a/catkit/emulators/tests/test_npoint_tiptilt.py
+++ b/catkit/emulators/tests/test_npoint_tiptilt.py
@@ -1,13 +1,117 @@
+import functools
+import itertools
 import os
+import struct
 
-from catkit.emulators.npoint_tiptilt import SimnPointTipTiltController
+import pytest
+
+from catkit.hardware.npoint.nPointTipTiltController import Commands, Parameters, NPointTipTiltController
+from catkit.emulators.npoint_tiptilt import SimNPointTipTiltController
 
 vendor_id = 1027
 product_id = 24596
 
 
-def test_init():
-    SimnPointTipTiltController(config_id="npoint_tiptilt_lc_400",
+Controller = functools.partial(SimNPointTipTiltController,
+                               config_id="npoint_tiptilt_lc_400",
                                vendor_id=vendor_id,
                                product_id=product_id,
                                library_path=os.path.abspath(__file__))
+
+
+def test_init():
+    Controller()
+
+
+def test_get_status():
+    with Controller() as controller:
+        for channel in controller.channels:
+            controller.get_status(channel)
+
+
+@pytest.mark.parametrize(("parameter", "channel", "value"),
+                         itertools.product([param for param in Parameters],
+                                           [channel for channel in NPointTipTiltController.channels],
+                                           [value for value in (0, 1)]))
+def test_set(parameter, channel, value):
+    with Controller() as controller:
+        controller.set(parameter, channel, value)
+        assert value == controller.instrument_lib.value_store[channel][parameter]
+
+
+@pytest.mark.parametrize(("parameter", "channel"),
+                         itertools.product([param for param in Parameters],
+                                           [channel for channel in NPointTipTiltController.channels]))
+def test_get(parameter, channel):
+    with Controller() as controller:
+        assert controller.get(parameter, channel) == 0
+
+
+@pytest.mark.parametrize(("parameter", "channel", "value"),
+                         itertools.product([param for param in Parameters],
+                                           [channel for channel in NPointTipTiltController.channels],
+                                           [value for value in (0, 1)]))
+def test_set_and_check(parameter, channel, value):
+    with Controller() as controller:
+        controller.set(parameter, channel, value)
+
+
+@pytest.mark.parametrize("value", (True, False))
+def test_set_closed_loop(value):
+    with Controller() as controller:
+        controller.set_closed_loop(value)
+
+
+@pytest.mark.parametrize(("command", "parameter", "channel", "value"),
+                         itertools.product([command for command in (Commands.SET, Commands.GET)],
+                                           [param for param in Parameters],
+                                           [channel for channel in NPointTipTiltController.channels],
+                                           [value for value in (0, 1)]))
+def test_message_parser(command, parameter, channel, value):
+    address = NPointTipTiltController.build_address(parameter, channel)
+    byte_value = struct.pack(NPointTipTiltController.endian + 'I', value)
+    message = b''.join([command.value, address, byte_value, NPointTipTiltController.endpoint])
+
+    parsed_command, parsed_parameter, parsed_address, parsed_channel, parsed_value = NPointTipTiltController.parse_message(message)
+
+    assert parsed_command is command
+    assert parsed_parameter is parameter
+    assert parsed_address == address
+    assert parsed_channel == channel
+    assert parsed_value == value
+
+
+@pytest.mark.parametrize(("parameter", "channel"),
+                         itertools.product([param for param in Parameters],
+                                           [channel for channel in NPointTipTiltController.channels]))
+def test_address(parameter, channel):
+    with Controller() as controller:
+        new_address = SimNPointTipTiltController.build_address(parameter, channel)
+        cmd_key = parameter.name.lower()
+        cmd_type = "get"  # Irrelevant as it's not apart of the address.
+        assert new_address == controller._build_message(cmd_key, cmd_type, channel)[0][1:5]
+
+
+@pytest.mark.skip
+@pytest.mark.parametrize(("parameter", "channel"),
+                         itertools.product([param for param in Parameters],
+                                           [channel for channel in NPointTipTiltController.channels]))
+def test_get(parameter, channel):
+    with Controller() as controller:
+        controller.get(parameter, channel)
+        cmd_key = parameter.name.lower()
+        cmd_type = "get"  # Irrelevant as it's not apart of the address.
+        assert controller.instrument_lib.message == controller._build_message(cmd_key, cmd_type, channel)[0]
+
+
+@pytest.mark.skip
+@pytest.mark.parametrize(("parameter", "channel", "value"),
+                         itertools.product([param for param in Parameters],
+                                           [channel for channel in NPointTipTiltController.channels],
+                                           [value for value in (0, 1)]))
+def test_set(parameter, channel, value):
+    with Controller() as controller:
+        controller.set(parameter, channel, value)
+        cmd_key = parameter.name.lower()
+        cmd_type = "set"  # Irrelevant as it's not apart of the address.
+        assert controller.instrument_lib.message == controller._build_message(cmd_key, cmd_type, channel, value)

--- a/catkit/emulators/tests/test_npoint_tiptilt.py
+++ b/catkit/emulators/tests/test_npoint_tiptilt.py
@@ -15,8 +15,7 @@ product_id = 24596
 Controller = functools.partial(SimNPointTipTiltController,
                                config_id="npoint_tiptilt_lc_400",
                                vendor_id=vendor_id,
-                               product_id=product_id,
-                               library_path=os.path.abspath(__file__))
+                               product_id=product_id)
 
 
 def test_init():

--- a/catkit/hardware/npoint/nPointTipTiltController.py
+++ b/catkit/hardware/npoint/nPointTipTiltController.py
@@ -333,7 +333,7 @@ class nPointTipTiltController(CloseLoopController):
         if value == set_value:
             self.log.info('Command successful: {} == {}.'.format(value, set_value))
         else:
-            self.log.info('Command was NOT sucessful : {} != {}.'.format(value, set_value))
+            raise ValueError('Command was NOT sucessful : {} != {}.'.format(value, set_value))
 
     @usb_except
     def get_config(self):

--- a/catkit/hardware/npoint/nPointTipTiltController.py
+++ b/catkit/hardware/npoint/nPointTipTiltController.py
@@ -45,8 +45,8 @@ def usb_except(function):
     return wrapper
 
 
-class nPointTipTilt():
-    """nPointTipTilt connection class. 
+class nPointTipTiltController():
+    """nPointTipTiltController connection class. 
 
     This nPointTipTilt class acts as a useful connection and storage vehicle 
     for commands sent to the nPoint FTID LC400 controller. It has built in 
@@ -55,6 +55,8 @@ class nPointTipTilt():
     and set the default configuration. Memory managers in the back end 
     should close the connection when the time is right.
     """
+    
+    instrument_lib = usb.core
 
     # Define this library mapping as a static attribute.
     library_mapping = {'libusb0': libusb0, 'libusb1': libusb1}
@@ -119,7 +121,7 @@ class nPointTipTilt():
         self.logger.addHandler(ch)
         
         # Instantiate the device
-        self.dev = usb.core.find(idVendor=self.vendor_id, idProduct=self.product_id, backend=self.backend)
+        self.dev = self.instrument_lib.find(idVendor=self.vendor_id, idProduct=self.product_id, backend=self.backend)
         if self.dev is None:
             self.close_logger()
             raise NameError("Go get the device sorted you knucklehead.")

--- a/catkit/hardware/npoint/nPointTipTiltController.py
+++ b/catkit/hardware/npoint/nPointTipTiltController.py
@@ -1,5 +1,5 @@
 """
-Interface for the nPoint Tip/Tilt close loop controller. 
+Interface for the nPoint Tip/Tilt closed loop controller. 
 Connects to the controller via usb, and then sends and recieves hex
 messages to send commands, check the status, and put error handling over
 top. 
@@ -29,7 +29,7 @@ import usb.core
 import usb.util
 
 from catkit.config import CONFIG_INI
-from catkit.interfaces.CloseLoopController import CloseLoopController
+from catkit.interfaces.ClosedLoopController import ClosedLoopController
 
 
 ## -- FUNCTIONS and FIDDLING 
@@ -48,7 +48,7 @@ def usb_except(function):
     return wrapper
 
 
-class nPointTipTiltController(CloseLoopController):
+class nPointTipTiltController(ClosedLoopController):
     """nPointTipTiltController connection class. 
 
     This nPointTipTilt class acts as a useful connection and storage vehicle 

--- a/catkit/hardware/npoint/nPointTipTiltController.py
+++ b/catkit/hardware/npoint/nPointTipTiltController.py
@@ -1,6 +1,6 @@
 """
 Interface for the nPoint Tip/Tilt closed loop controller. 
-Connects to the controller via usb, and then sends and recieves hex
+Connects to the controller via usb, and then sends and receives
 messages to send commands, check the status, and put error handling over
 top. 
 
@@ -10,17 +10,12 @@ CATKIT_LIBUSB_PATH = 'C:\\Users\\HICAT\\Desktop\\libusb-win32-bin-1.2.6.0\\bin\\
 """
 
 
-
-## -- IMPORTS
-
 import enum
 import functools
+import math
 import os
 import struct
 import time
-import warnings
-
-from numpy import double
 
 from usb.backend import libusb0, libusb1
 import usb.core
@@ -29,19 +24,19 @@ import usb.util
 from catkit.interfaces.ClosedLoopController import ClosedLoopController
 
 
-class Variables(enum.Enum):
-    LOOP = '084'
-    P_GAIN = '720'
-    I_GAIN = '728'
-    D_GAIN = '730'
+class Parameters(enum.Enum):
+    # These get summed with the channel to yield an address so for convenience leave these as ints.
+    LOOP = 0x84
+    P_GAIN = 0x720
+    I_GAIN = 0x728
+    D_GAIN = 0x730
 
 
 class Commands(enum.Enum):
-    SET = 162
-    SECOND_MSG = 163
-    GET = 164
+    SET = b'0xA2'
+    SECOND_MSG = b'0xA3'
+    GET = b'0xA4'
 
-## -- FUNCTIONS and FIDDLING 
 
 # Decorator with error handling
 def usb_except(function):
@@ -51,14 +46,14 @@ def usb_except(function):
     def wrapper(self, *args, **kwargs):
         try:
             return function(self, *args, **kwargs)
-        except usb.core.USBError as e:
-            raise Exception('USB connection error.') from e
+        except usb.core.USBError as error:
+            raise Exception('USB connection error.') from error
 
     return wrapper
 
 
-class nPointTipTiltController(ClosedLoopController):
-    """nPointTipTiltController connection class. 
+class NPointTipTiltController(ClosedLoopController):
+    """NPointTipTiltController connection class.
 
     This nPointTipTilt class acts as a useful connection and storage vehicle 
     for commands sent to the nPoint FTID LC400 controller. It has built in 
@@ -70,10 +65,19 @@ class nPointTipTiltController(ClosedLoopController):
     
     instrument_lib = usb.core
 
-    # Define this library mapping as a static attribute.
     library_mapping = {'libusb0': libusb0, 'libusb1': libusb1}
+    # TODO: THe following usb_<x>_endpoint, I think, can be, and therefore should be, retrieved from self.get_config().
+    usb_read_endpoint = b'0x81'
+    usb_send_endpoint = b'0x02'
+    endpoint = b'0x55'
+    # The channels get summed with the parameters to yield an address so for convenience leave these as ints.
+    base_channel_address = 0x11830000
+    channel_address_offset = 0x1000
+    channels = (1, 2)
+    endian = '<'  # Little endian.
+    message_length = 100
 
-    def initialize(self, vendor_id, product_id, library_path=None, library='libusb0'):
+    def initialize(self, vendor_id, product_id, library_path=None, library='libusb0', timeout=60):
         """Initial function to set vendor and product id parameters.
         Parameters
         ----------
@@ -91,6 +95,7 @@ class nPointTipTiltController(ClosedLoopController):
         self.vendor_id = vendor_id
         self.product_id = product_id
         self.dev = None
+        self.timeout = timeout
 
         self.library_path = os.environ.get('CATKIT_LIBUSB_PATH') if library_path is None else library_path
         if not self.library_path:
@@ -104,250 +109,300 @@ class nPointTipTiltController(ClosedLoopController):
             self.library = self.library_mapping[library]
             self.backend = self.library.get_backend(find_library=lambda x: self.library_path)
 
-    def _build_message(self, var, command, channel, value=None):
-        """Builds the message to send to the controller. The messages
-        must be 10 or 6 bytes, in significance increasing order (little 
-        endian.) 
-
-        The format of the message to write to a new location is :
-        [1 byte type (0xA2)] [4 byte address] [4 byte int/first half of float] 
-        [1 byte sign off (0x55)]
-        
-        To write something else to the same location :
-        [1 byte type (0xA3)] [4 byte message (second half of float)] 
-        [1 byte sign off]
-
-        To read from a location : 
-        [1 byte type (0xA4)] [4 byte address] [4 byte numReads][1 byte sign off]
-        
-        Parameters
-        ----------
-        var : Variables enum
-            The key to point toward the p/i/d_gain or loop.
-        command : Commands enum
-            Either Commands.GET to return a message or Commands.SET to write a command.
-        channel : int
-            1 or 2 for which channel.
-        value : int/float, optional
-            If it's writing a command, what value to set it to. This 
-            will fail if it needs a value and is not given one.
-
-        Returns
-        -------
-        message : list of bytes
-            An list of bytes messages. One if it's call to get a value 
-            or a simple int message, or two if it needs to write a float 
-            and use two messages.
+    @classmethod
+    def build_address(cls, parameter, channel):
+        """ Builds the message to send to the controller.
+        Memory offsets are summed with a channel base address to set the parameter for a specific channel.
+        Channels are separated by an offset of 0x1000.
+        0x11831000 := Ch1 base address
+        0x11832000 := Ch2 base address
         """
 
-        addr = 11830000 + 1000 * channel + var.value
-        addr = f'0x{addr}'
-        
-        # Note that the < specifies the little endian/significance increasing order here
-        addr = struct.pack('<Q', int(addr, 16))
+        if parameter not in Parameters:
+            raise ValueError(f"Parameter must be one of {[param for param in Parameters]}.")
 
-        # Now build message or messages 
-        message = []
+        if channel not in cls.channels:
+            raise ValueError(f"Channel must be one of {cls.channels}")
 
-        if command is Commands.GET:
-            if value is not None:
-                warnings.warn('You specified a value but nothing will happen to it.')
-            
-            message.append(b'\xa4' + addr[:4] + b'\x02\x00\x00\x00\x55')
+        # + := int addition.
+        address = cls.base_channel_address + channel*cls.channel_address_offset + parameter.value
 
-        elif command is Commands.SET:
-            if value is None:
-                raise ValueError("Value is required.")
+        return struct.pack(cls.endian + 'I', address)  # 'I' := unsigned int.
 
-            if var is Variables.LOOP:
-                if value not in (1, 0):
-                    raise ValueError("1 or 0 value is required for loop.")
-
-                # Convert to hex
-                val = struct.pack('<I', value)
-                message.append(b'\xa2' + addr[:4] + val + b'\x55')
-
-            elif var in Variables:
-                if type(value) == int:
-                    value = float(value)
-
-                elif type(value) not in [float, double]:
-                    raise TypeError("Int or float value is required for gain.")
-                
-                # Convert to hex double (64 bit)
-                val = struct.pack('<d', value)
-
-                message.append(b'\xa2' + addr[:4] + val[:4] + b'\x55')
-                message.append(b'\xa3' + val[4:] + b'\x55')
-        
-            else:
-                raise ValueError("cmd_key must be 'loop' or 'p/i/d_gain'.")
-        else:
-            raise NotImplementedError('cmd_type must be get or set.')
-        
-        return message
-    
     def _close(self):
-        """Function for the close controller behavior."""
-
-        for channel in [1, 2]:
-            for var in Variables:
-                self.command(var, channel, 0)
+        # Reset everything to 0.
+        for channel in self.channels:
+            for parameter in Parameters:
+                self.set(parameter, channel, 0)
 
     def _open(self):
-        """ Open function to connect to device. """
-
-        # Instantiate the device
+        # Instantiate the device.
         self.instrument = self.instrument_lib.find(idVendor=self.vendor_id, idProduct=self.product_id, backend=self.backend)
         if self.instrument is None:
             raise NameError(f"Go get the device sorted you knucklehead.\nVendor id {self.vendor_id} and product id {self.product_id} could not be found and connected.")
              
         # Set to default configuration -- for LC400 this is the right one.
-        self.dev = self.instrument # For legacy purposes
+        self.dev = self.instrument  # For legacy purposes
         self.instrument.set_configuration()
         self.log.info('nPointTipTilt instantiated and logging online.')
         
         return self.instrument
 
-    def _read_response(self, response_type, return_timer=False, max_tries=10):
-        """Read response from controller.
-
-        Parameters
-        ----------
-        response_type : str
-            '<I' or '<d', for an integer or double expected response.
-        return_timer : bool, optional 
-            Whether or not to return the tries and timing info.
-        max_tries : int, optional
-            How many times to check for a response. Set to 10.
-
-        Returns
-        -------
-        value : int/float
-            The int or float being sent.
-        time_elapsed : float
-            How long it took to read, only returned if return_timer=True.
-        tries : int
-            How many times it checked the message, only returned if
-            return_timer=True.
-        """
-
+    def _read(self):
+        """ Read a response from controller. """
         resp = ''
-        tries = 0
-        
         start = time.time()
-        
-        # The junk message is 3 characters, so look for a longer one.
-        
-        endpoint = 0x81
-        message_length = 100
-        timeout = 1000
-        while len(resp) < 4 and tries < max_tries:
-            resp = self.instrument.read(endpoint, message_length, timeout) 
-            tries += 1 
-        time_elapsed = time.time() - start
-        
+        resp = self.instrument.read(self.usb_read_endpoint, self.message_length, self.timeout)
+        self.log.debug(f'It took {start - time.time()}s to read response.')
+
         if len(resp) < 4:
-            raise ValueError("No response was ever read.")
-            
-        else:
-        
-            # Value is never more than 8 bits, so grab those last ones
-            val = resp[7:-1]
-            if response_type == '<I':
-                value = struct.unpack(response_type, val[:4])
-            else:
-                value = struct.unpack(response_type, val)
-            # Value will be a 1D tuple and we want the value
-            value = value[0]
+            raise RuntimeError("No response from controller.")
 
-            if return_timer:
-                return value, time_elapsed, tries
-            else:
-                return value
-    
-    def _send_message(self, msg):
-        """Send the message to the controller.
+        return resp
 
-        Parameters
-        ----------
-        msg : list of bytes
-            A controller ready message or messages.
-        """
-        
-        endpoint = 0x02
-        timeout = 100
-        for message in msg:
-            self.instrument.write(endpoint, message, timeout)
-    
+    def _send(self, message):
+        """ Send the message(s) to the controller. """
+        message = message if isinstance(message, (tuple, list)) else [message]
+        for msg in message:
+            self.instrument.write(self.usb_send_endpoint, msg, self.timeout)
+
     @usb_except
-    def command(self, var, channel, value):
-        """Function to send a command to the controller and read back 
-        to make sure it matches. 
-
-        Parameters
-        ----------
-        var : Commands enum
-            Whether to set the "loop" or "p/i/d_gain".
-        channel : int
-            What channel to set.
-        value : int/flot
-            What value to set.
+    def get(self, parameter, channel):
         """
+        Read Array Command
+            Number of bytes: 10
+            Format: 0xA4 [addr] [numReads] 0x55
+            Return Value: 0xA4 [addr] [data 1].....[data N] 0x55
+        """
+        # Construct message.
+        n_reads = 1 if parameter is Parameters.LOOP else 2
+        n_reads = struct.pack(NPointTipTiltController.endian + 'I', n_reads)
+        address = self.build_address(parameter, channel)
+        message = b''.join([Commands.GET.value, address, n_reads, self.endpoint])
 
-        set_message = self._build_message(var, Commands.SET, channel, value)
-        get_message = self._build_message(var, Commands.GET, channel)
+        # Send GET.
+        self._send(message)
 
-        self._send_message(set_message)
-        self._send_message(get_message)
-        if var is Variables.LOOP:
-            response_type = '<I'
+        # Read response.
+        resp = self._read()
+
+        # Parse response.
+        resp_command, resp_parameter, resp_address, resp_channel, value = self.parse_message(resp)
+
+        # Check to ensure that reads are in sync.
+        if resp_command is not Commands.GET:
+            raise RuntimeError(f"Reads and writes out of sync. Expected Command '{Commands.GET}' but got '{resp_command}")
+        if resp_parameter is not parameter:
+            raise RuntimeError(f"Reads and writes out of sync. Expected Parameter '{parameter}' but got '{resp_parameter}")
+        if address != resp_address:
+            raise RuntimeError(f"Reads and writes out of sync. Expected address '{address}' but got '{resp_address}")
+        if resp_channel != channel:
+            raise RuntimeError(f"Reads and writes out of sync. Expected channel '{channel}' but got '{resp_channel}")
+
+        return value
+
+    @usb_except
+    def set(self, parameter, channel, value):
+        """
+        Write Single Location Command
+            Number of bytes: 10
+            Format: 0xA2 [addr] [data] 0x55
+            Return Value: none
+        Write Next Command
+            Number of bytes: 6
+            Format: 0xA3 [data] 0x55
+            Return Value: none
+        """
+        if not isinstance(value, (int, float)):
+            raise TypeError(f"Parameter values must be int or float not {type(value)}")
+
+        address = self.build_address(parameter, channel)
+
+        if parameter is Parameters.LOOP:
+            value = struct.pack(NPointTipTiltController.endian + 'I', 1 if value else 0)
+            self._send(b''.join([Commands.SET.value, address, value, self.endpoint]))
         else:
-            response_type = '<d'
-        set_value, time_elapsed, tries = self._read_response(response_type, return_timer=True)
-        
-        self.log.info(f'It took {time_elapsed} seconds and {tries} tries for the message to return.')
-        if value == set_value:
-            self.log.info(f'Command successful: {value} == {set_value}.')
-        else:
-            raise ValueError(f'Command was NOT sucessful : {value} != {set_value}.')
+            value = struct.pack(NPointTipTiltController.endian + 'd', float(value))
+            # Send value in two halves.
+            self._send([b''.join([Commands.SET.value, address, value[:4], self.endpoint]),
+                        b''.join([Commands.SECOND_MSG.value, value[4:], self.endpoint])])
+
+    @usb_except
+    def set_and_check(self, parameter, channel, value):
+        self.set(parameter, channel, value)
+        set_value = self.get(parameter, channel)
+        if value != set_value:
+            raise ValueError(f'Command was NOT successful : {value} != {set_value}.')  # RT error?
+        self.log.debug(f'Command successful: {value} == {set_value}.')
 
     @usb_except
     def get_config(self):
         """Checks the feasible configurations for the device."""
-        
         for cfg in self.instrument:
             self.log.info('Device config : ')
             self.log.info(cfg)
         
     @usb_except
     def get_status(self, channel):
-        """Checks the status of the loop, and p/i/d_gain for 
-        the specified channel.
+        """ Get the value of all parameter: loop, and p/i/d_gain for the specified channel. Returns a dict. """
+        value_dict = {}
+        for parameter in Parameters:
+            value_dict[parameter] = self.get(parameter, channel)
+        self.log.info(f"Status: {value_dict}")
+        return value_dict 
+
+    def set_closed_loop(self, active=True):
+        """ Activate closed-loop control on all channels. """
+        for channel in self.channels:
+            self.set_and_check(Parameters.LOOP, channel, active)
+
+    @classmethod
+    def parse_message(cls, message):
+        """ Parse message.
+
+        Read Array Command
+            Number of bytes: 10
+            Format: 0xA4 [addr] [numReads] 0x55
+            Return Value: 0xA4 [addr] [data 1].....[data N] 0x55
+        Write Single Location Command
+            Number of bytes: 10
+            Format: 0xA2 [addr] [data] 0x55
+            Return Value: none
+        Write Next Command
+            Number of bytes: 6
+            Format: 0xA3 [data] 0x55
+            Return Value: none
+
+        Returns:
+            Command, Parameter, address, channel, data
+        """
+
+        # Parse command
+        try:
+            command = Commands(message[:4])
+        except ValueError as error:
+            raise NotImplementedError('Non implemented command found in message.') from error
+
+        parameter = None
+        address = None
+        channel = None
+        if command in (Commands.GET, Commands.SET):
+            # Parse address
+            address = message[4:8]
+
+            # Parse channel
+            int_address = struct.unpack(cls.endian + 'I',address)[0]
+            channel = math.floor((int_address - cls.base_channel_address) / cls.channel_address_offset)
+            if channel not in cls.channels:
+                raise ValueError(f"Channel out of bounds. Received '{channel}' expected one of ({cls.channels})")
+
+            # Parse parameter
+            try:
+                parameter = Parameters(int_address - cls.base_channel_address - cls.channel_address_offset * channel)
+            except ValueError as error:
+                raise NotImplementedError('Non implemented parameter found in message.') from error
+
+        # Parse value.
+        if command in (Commands.SET, Commands.SECOND_MSG):
+            data = struct.unpack(cls.endian + 'I', message[-8:-4])[0]
+        elif command is Commands.GET:
+            # For GET, message could be either that sent or that received. E.g., either of the following:
+            # 0xA4 [addr] [numReads] 0x55
+            # 0xA4 [addr] [data 1].....[data N] 0x55
+            data_block = message[8:-4]
+            data_block_byte_length = len(data_block)//4
+            if data_block_byte_length == 1:
+                data_type_fmt = 'I'
+            elif data_block_byte_length == 2:
+                data_type_fmt = 'd'
+            else:
+                raise NotImplementedError(f"Supports only 32b ints and 64b floats. Received {data_block_byte_length * 32}b data block.")
+            data = struct.unpack(cls.endian + data_type_fmt, data_block)[0]
+        else:
+            raise NotImplementedError('Non implemented command found in message.')
+
+        return command, parameter, address, channel, data
+
+    @classmethod
+    def _build_message(self, cmd_key, cmd_type, channel, value=None):
+        """Builds the message to send to the controller. The messages
+        must be 10 or 6 bytes, in significance increasing order (little
+        endian.)
+        The format of the message to write to a new location is :
+        [1 byte type (0xA2)] [4 byte address] [4 byte int/first half of float]
+        [1 byte sign off (0x55)]
+
+        To write something else to the same location :
+        [1 byte type (0xA3)] [4 byte message (second half of float)]
+        [1 byte sign off]
+        To read from a location :
+        [1 byte type (0xA4)] [4 byte address] [4 byte numReads][1 byte sign off]
 
         Parameters
         ----------
+        cmd_key : str
+            The key to point toward the p/i/d_gain or loop.
+        cmd_type : str
+            Either "get" to return a message or "set" to write a command.
         channel : int
-            The channel to check.
-
+            1 or 2 for which channel.
+        value : int/float, optional
+            If it's writing a command, what value to set it to. This
+            will fail if it needs a value and is not given one.
         Returns
         -------
-        value_dict : dict
-            A dictionary with a setting for each parameter.
+        message : list of bytes
+            An list of bytes messages. One if it's call to get a value
+            or a simple int message, or two if it needs to write a float
+            and use two messages.
         """
-        
-        value_dict = {}
-        self.log.info(f"For channel {channel}.")
-        for var in Variables:
-            self._send_message(self._build_message(var, Commands.GET, channel))
-            if var is Variables.LOOP:
-                response_type = '<I'
+
+        cmd_dict = {'loop': 84, 'p_gain': 720, 'i_gain': 728, 'd_gain': 730}
+
+        addr = 11830000 + 1000 * channel + cmd_dict[cmd_key]
+        addr = '0x{}'.format(addr)
+
+        # Note that the < specifies the little endian/signifigance increasing order here
+        addr = struct.pack('<Q', int(addr, 16))
+
+        # Now build message or messages
+        message = []
+
+        if cmd_type == 'get':
+            if value is not None:
+                import warnings
+                warnings.warn('You specified a value but nothing will happen to it.')
+
+            message.append(b'\xa4' + addr[:4] + b'\x02\x00\x00\x00\x55')
+
+        elif cmd_type == 'set':
+            if value is None:
+                raise ValueError("Value is required.")
+
+            if cmd_key == 'loop':
+                if value not in [1, 0]:
+                    raise ValueError("1 or 0 value is required for loop.")
+
+                # Convert to hex
+                val = struct.pack('<I', value)
+                message.append(b'\xa2' + addr[:4] + val + b'\x55')
+
+            elif cmd_key in ['p_gain', 'i_gain', 'd_gain']:
+                if type(value) == int:
+                    value = float(value)
+
+                elif type(value) not in [float]:
+                    raise TypeError("Int or float value is required for gain.")
+
+                # Convert to hex double (64 bit)
+                val = struct.pack('<d', value)
+
+                message.append(b'\xa2' + addr[:4] + val[:4] + b'\x55')
+                message.append(b'\xa3' + val[4:] + b'\x55')
+
             else:
-                response_type = '<d'
-            value = self._read_response(response_type)
-            self.log.info(f"For parameter : {var} the value is {value}")
-            value_dict[var] = value
+                raise ValueError("cmd_key must be 'loop' or 'p/i/d_gain'.")
+        else:
+            raise NotImplementedError('cmd_type must be get or set.')
 
-        return value_dict 
-
-
+        return message

--- a/catkit/hardware/npoint/nPointTipTiltController.py
+++ b/catkit/hardware/npoint/nPointTipTiltController.py
@@ -160,7 +160,7 @@ class nPointTipTiltController(ClosedLoopController):
         cmd_dict = {'loop': 84, 'p_gain': 720, 'i_gain': 728, 'd_gain': 730}
 
         addr = 11830000 + 1000*channel + cmd_dict[cmd_key]
-        addr = '0x{}'.format(addr)
+        addr = f'0x{addr}'
         
         # Note that the < specifies the little endian/signifigance increasing order here
         addr = struct.pack('<Q', int(addr, 16))
@@ -326,11 +326,11 @@ class nPointTipTiltController(ClosedLoopController):
             response_type = '<d'
         set_value, time_elapsed, tries = self._read_response(response_type, return_timer=True)
         
-        self.log.info('It took {} seconds and {} tries for the message to return.'.format(time_elapsed, tries))
+        self.log.info('It took {time_elapsed} seconds and {tries} tries for the message to return.')
         if value == set_value:
-            self.log.info('Command successful: {} == {}.'.format(value, set_value))
+            self.log.info(f'Command successful: {value} == {set_value}.')
         else:
-            raise ValueError('Command was NOT sucessful : {} != {}.'.format(value, set_value))
+            raise ValueError(f'Command was NOT sucessful : {value} != {set_value}.')
 
     @usb_except
     def get_config(self):
@@ -362,7 +362,7 @@ class nPointTipTiltController(ClosedLoopController):
                     'loop': self._build_message('loop', 'get', channel)}
         
         value_dict = {}
-        self.log.info("For channel {}.".format(channel))
+        self.log.info(f"For channel {channel}.")
         for key in read_msg:
             self._send_message(read_msg[key])
             if key == 'loop':
@@ -370,7 +370,7 @@ class nPointTipTiltController(ClosedLoopController):
             else:
                 response_type = '<d'
             value = self._read_response(response_type)
-            self.log.info("For parameter : {} the value is {}".format(key, value))
+            self.log.info(f"For parameter : {key} the value is {value}")
             value_dict[key] = value
 
         return value_dict 

--- a/catkit/hardware/npoint/nPointTipTiltController.py
+++ b/catkit/hardware/npoint/nPointTipTiltController.py
@@ -28,7 +28,6 @@ from usb.backend import libusb0, libusb1
 import usb.core
 import usb.util
 
-from catkit.config import CONFIG_INI
 from catkit.interfaces.ClosedLoopController import ClosedLoopController
 
 
@@ -64,10 +63,8 @@ class nPointTipTiltController(ClosedLoopController):
     # Define this library mapping as a static attribute.
     library_mapping = {'libusb0': libusb0, 'libusb1': libusb1}
 
-    def initialize(self, vendor_id=None, product_id=None, library_path=None, library=None):
-        """Initial function to set vendor and product ide parameters. Anything 
-        set to None will attempt to pull from the config file.
-        
+    def initialize(self, vendor_id, product_id, library_path=None, library=None):
+        """Initial function to set vendor and product ide parameters.         
         Parameters
         ----------
         vendor_id : int
@@ -80,9 +77,9 @@ class nPointTipTiltController(ClosedLoopController):
             Which libusb library, right now supports libusb0 and libusb1. Defaults to None.
         """
         
-        # Pull device specifics from config file
-        self.vendor_id = CONFIG_INI.get(self.config_id, 'vendor_id') if vendor_id is None else vendor_id
-        self.product_id = CONFIG_INI.get(self.config_id, 'product_id') if product_id is None else product_id
+        # Device specifics
+        self.vendor_id = vendor_id
+        self.product_id = product_id
         
         self.library_path = os.environ.get('CATKIT_LIBUSB_PATH') if library_path is None else library_path
         if not self.library_path:

--- a/catkit/hardware/npoint/nPointTipTiltController.py
+++ b/catkit/hardware/npoint/nPointTipTiltController.py
@@ -81,8 +81,8 @@ class nPointTipTiltController(CloseLoopController):
         """
         
         # Pull device specifics from config file
-        self.vendor_id = CONFIG_INI.get('npoint_tiptilt_lc_400', 'vendor_id') if vendor_id is None else vendor_id
-        self.product_id = CONFIG_INI.get('npoint_tiptilt_lc_400', 'product_id') if product_id is None else product_id
+        self.vendor_id = CONFIG_INI.get(self.config_id, 'vendor_id') if vendor_id is None else vendor_id
+        self.product_id = CONFIG_INI.get(self.config_id, 'product_id') if product_id is None else product_id
         
         self.library_path = os.environ.get('CATKIT_LIBUSB_PATH') if library_path is None else library_path
         if not self.library_path:
@@ -225,10 +225,11 @@ class nPointTipTiltController(CloseLoopController):
             raise NameError("Go get the device sorted you knucklehead.")
              
         # Set to default configuration -- for LC400 this is the right one.
-        self.instrument = self.instrument # For lecary purposes
+        self.dev = self.instrument # For legacy purposes
         self.instrument.set_configuration()
         self.log.info('nPointTipTilt instantiated and logging online.')
-
+        
+        return self.instrument
 
     def _read_response(self, response_type, return_timer=False, max_tries=10):
         """Read response from controller.

--- a/catkit/interfaces/CloseLoopController.py
+++ b/catkit/interfaces/CloseLoopController.py
@@ -1,0 +1,17 @@
+from abc import ABC, abstractmethod
+
+from catkit.interfaces.Instrument import Instrument
+
+
+class CloseLoopController(Instrument, ABC):
+    """ Interface class for a close loop controller. """
+
+
+    @abstractmethod
+    def command(self, cmd_key, channel, value):
+        """Sends a command to the close loop. """
+
+    @abstractmethod
+    def get_status(self, channel):
+        """Gets the status of the controller."""
+

--- a/catkit/interfaces/ClosedLoopController.py
+++ b/catkit/interfaces/ClosedLoopController.py
@@ -6,12 +6,23 @@ from catkit.interfaces.Instrument import Instrument
 class ClosedLoopController(Instrument, ABC):
     """ Interface class for a closed loop controller. """
 
+    @abstractmethod
+    def set_closed_loop(self, active=True):
+        """ Activate closed-loop control on all channels. """
 
     @abstractmethod
-    def command(self, var, channel, value):
-        """Sends a command to the closed-loop controller. """
+    def get(self, var, channel):
+        """ Get a command from the closed-loop controller. """
+
+    @abstractmethod
+    def set(self, var, channel, value):
+        """ Set a command on the closed-loop controller. """
+
+    @abstractmethod
+    def set_and_check(self, parameter, channel, value):
+        """ Set a command on the closed-loop controller and the get and checl that it was correctly set. """
 
     @abstractmethod
     def get_status(self, channel):
-        """Gets the status of the closed-loop controller."""
+        """ Gets the status of the closed-loop controller. """
 

--- a/catkit/interfaces/ClosedLoopController.py
+++ b/catkit/interfaces/ClosedLoopController.py
@@ -8,10 +8,10 @@ class ClosedLoopController(Instrument, ABC):
 
 
     @abstractmethod
-    def command(self, cmd_key, channel, value):
-        """Sends a command to the close loop. """
+    def command(self, var, channel, value):
+        """Sends a command to the closed-loop controller. """
 
     @abstractmethod
     def get_status(self, channel):
-        """Gets the status of the controller."""
+        """Gets the status of the closed-loop controller."""
 

--- a/catkit/interfaces/ClosedLoopController.py
+++ b/catkit/interfaces/ClosedLoopController.py
@@ -3,8 +3,8 @@ from abc import ABC, abstractmethod
 from catkit.interfaces.Instrument import Instrument
 
 
-class CloseLoopController(Instrument, ABC):
-    """ Interface class for a close loop controller. """
+class ClosedLoopController(Instrument, ABC):
+    """ Interface class for a closed loop controller. """
 
 
     @abstractmethod


### PR DESCRIPTION
As we fold the nPoint into our every day operations, I wanted to make sure we had an emulator for it first. In order to write them in the style of of the new `catkit` emulators this necessitated overhauling the nPoint code as well. 

So in this PR : 
1. Created `CloseLoopController` interface class.
2. Refactored the `nPointTipTiltController` class to match new hardware class. 
3. Wrote npoint simulator. 

I have two lingering issues with the npoint simulator as written, one of which is actually an obstacle, one is a *would be nice if...*.

Obstacle : something is going a little funny with the context managed `with` style open when I play around with the simulator. Maybe @jamienoss can help me figure out why?

The following runs as expected : 

```
np = SimnPointTipTiltController(...)
np._open()
np.do_whatever_test_action
```

If I do it doesn't seem to have run the `_open` that should be handled with the context manager.

```
with SimnPointTipTiltController(...) as np:
     np.do_whatever_test_action
```

Would be nice if : 
Right now, the emulator is not smart enough to actually store and return commands being sent. 
This is to say, if you send a command to the emulator to change the gain, it doesn't do this, and it doesn't know what the value it wants to set it. (This is especially tricky because when you send gain updates to the controller you have to send it in two messages and it makes it hard to programmatically reconstruct the message.) This being said -- this simulator doesn't need to have any hook with poppy / actually changing the image right now, so I don't see this as an issue, more of an ideal update in the future. 