### PR TITLE
Make move_time an absolute value so we don't end up with negative sleeps.

### DIFF
--- a/catkit/hardware/newport/NewportPicomotorController.py
+++ b/catkit/hardware/newport/NewportPicomotorController.py
@@ -187,8 +187,9 @@ class NewportPicomotorController(MotorController2):
         self._send_message(set_message, 'set')
         
         # Calculate time move will take so we don't overlap messages
+        # Keep in mind sometimes steps are negative
         # Default velocity is 2000 steps/second
-        move_time = value*self.sleep_per_step 
+        move_time = np.abs(value*self.sleep_per_step)
         time.sleep(move_time)
         
         set_value = float(self._send_message(get_message, 'get')) - float(initial_value)


### PR DESCRIPTION
Small bugfix for the picomotors. 