### PR TITLE
removed reference to white ups in catkit

### DIFF
--- a/catkit/emulators/tests/config.ini
+++ b/catkit/emulators/tests/config.ini
@@ -391,11 +391,6 @@ max_psf_bin_cts_per_microsec = 2187
 [cross_correlation]
 subpixel_upsample_factor = 3
 
-[white_ups]
-ip = 130.167.177.151
-port = 161
-snmp_oid = 1.3.6.1.4.1.534.1.3.5.0
-community = palapa
 
 [blue_ups]
 ip = 10.128.242.6


### PR DESCRIPTION
Catkit counterpart of the same PR in HiCAT. 
I checked the missing references to white_up using pycharm search functions. please one reviewer checks again. 

[Jira ticket here](https://jira.stsci.edu/browse/HICAT-750).