### PR TITLE
remove un-used camera references from catkit

### DIFF
--- a/catkit/emulators/tests/config.ini
+++ b/catkit/emulators/tests/config.ini
@@ -38,7 +38,6 @@ mtf_path = mathematica/scripts/mtf_sampling/sampling.wl
 
 [zwo_ASI1600MM]
 camera_name = ZWO ASI1600MM
-frames_path = Z:/Testbeds/HiCAT/Data/SBIG/CamF/AJprobeImages/Frames/
 gain = 0
 filename = probe_single_image.fit
 exposure_time_us = 30000
@@ -73,40 +72,6 @@ image_fliplr = false
 ; Must be a multiple of 8
 width = 464
 height = 464
-
-[zwo_ASI290MM_2]
-camera_name = ZWO ASI290MM(2)
-gain = 139
-bins = 1
-subarray_x = 1530
-subarray_y = 1078
-camera_chip_rotation = 0
-camera_chip_fliplr = false
-full_image = true
-image_rotation = 0
-image_fliplr = false
-
-; Must be a multiple of 8
-width = 464
-height = 464
-
-[zwo_ASI178MM_2]
-camera_name = ZWO ASI178MM(2)
-gain = 0
-bins = 1
-subarray_x = 1975
-subarray_y = 1030
-camera_chip_rotation = 0
-camera_chip_fliplr = false
-full_image = true
-image_rotation = 0
-image_fliplr = false
-max_counts = 45000
-min_counts = 40000
-
-; Must be a multiple of 8
-width = 1856
-height = 1856
 
 [zwo_ASI178MM_3]
 camera_name = ZWO ASI178MM(3)
@@ -146,26 +111,6 @@ min_counts = 40000
 ; Must be a multiple of 8
 width = 1856
 height = 1856
-
-[sbig_16803_1]
-camera_name = SBIG STX-16803(1)
-camera_serial_number = X14060355
-base_url = http://192.168.192.139:80/api/
-cooler_state = 0
-timeout = 100
-min_delay = 0.050
-bins = 1
-detector_width = 4096
-detector_length = 4096
-subarray_x = 2048
-subarray_y = 2048
-full_image = False
-image_rotation = 0
-image_fliplr = false
-
-; Unlike ZWO, need not be a multiple of 8
-width = 520
-height = 520
 
 [boston_kilo952]
 ; TODO: is this the serial number of the electronics (single box) or one of the dms?
@@ -527,7 +472,6 @@ diameter = none
 
 [testbed]
 imaging_camera = zwo_ASI178MM_3
-;pupil camera is currently unplugged, but it may end up being zwo_ASI178MM_1
 pupil_camera = zwo_ASI178MM_4
 phase_retrieval_camera = zwo_ASI1600MM
 laser_source = thorlabs_source_mcls1


### PR DESCRIPTION
counterpart PR for the catkit side... only removing references in the config.ini here, since for catkit we want to keep the obsolete camera implementation in case others want to use these one day. 

[Jira ticket here](https://jira.stsci.edu/browse/HICAT-751).