### PR TITLE
HICAT-755 Temporarily not running pytests against Python 3.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6]
         os: [windows-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v1
@@ -107,7 +107,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6]
         os: [windows-latest, ubuntu-latest]
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
This is in order to keep the CI runtime down (+ $ cost) until work is resumed
on #223 (HICAT-541 and HICAT-741).

Signed-off-by: James Noss <jnoss@stsci.edu>