### PR TITLE
HiCAT-687: implement phase retrieval code on HiCAT

### DIFF
--- a/catkit/hardware/boston/BostonDmController.py
+++ b/catkit/hardware/boston/BostonDmController.py
@@ -101,7 +101,7 @@ class BostonDmController(DeformableMirrorController):
 
         # Use DmCommand class to format the commands correctly (with zeros for other DM).
         dm1_command = dm1_command_object.to_dm_command(voltage_offset=dm1_voltage_offset)
-        dm2_command = dm2_command_object.to_dm_command(voltage_offset=dm2_voltage_offset
+        dm2_command = dm2_command_object.to_dm_command(voltage_offset=dm2_voltage_offset)
 
         # Add both arrays together (first half and second half) and send to DM.
         full_command = dm1_command + dm2_command

--- a/catkit/hardware/boston/BostonDmController.py
+++ b/catkit/hardware/boston/BostonDmController.py
@@ -90,7 +90,8 @@ class BostonDmController(DeformableMirrorController):
             # Update testbed_state.
             self.__close_dm_controller_testbed_state()
 
-    def apply_shape_to_both(self, dm1_command_object, dm2_command_object):
+    def apply_shape_to_both(self, dm1_command_object, dm2_command_object,
+                            dm1_voltage_offset=0, dm2_voltage_offset=0):
         """Combines both commands and sends to the controller to produce a shape on each DM."""
         self.log.info("Applying shape to both DMs")
 
@@ -99,8 +100,8 @@ class BostonDmController(DeformableMirrorController):
         dm2_command_object.dm_num = 2
 
         # Use DmCommand class to format the commands correctly (with zeros for other DM).
-        dm1_command = dm1_command_object.to_dm_command()
-        dm2_command = dm2_command_object.to_dm_command()
+        dm1_command = dm1_command_object.to_dm_command(voltage_offset=dm1_voltage_offset)
+        dm2_command = dm2_command_object.to_dm_command(voltage_offset=dm2_voltage_offset
 
         # Add both arrays together (first half and second half) and send to DM.
         full_command = dm1_command + dm2_command

--- a/catkit/hardware/boston/BostonDmController.py
+++ b/catkit/hardware/boston/BostonDmController.py
@@ -90,8 +90,7 @@ class BostonDmController(DeformableMirrorController):
             # Update testbed_state.
             self.__close_dm_controller_testbed_state()
 
-    def apply_shape_to_both(self, dm1_command_object, dm2_command_object,
-                            dm1_voltage_offset=0, dm2_voltage_offset=0):
+    def apply_shape_to_both(self, dm1_command_object, dm2_command_object):
         """Combines both commands and sends to the controller to produce a shape on each DM."""
         self.log.info("Applying shape to both DMs")
 
@@ -100,8 +99,8 @@ class BostonDmController(DeformableMirrorController):
         dm2_command_object.dm_num = 2
 
         # Use DmCommand class to format the commands correctly (with zeros for other DM).
-        dm1_command = dm1_command_object.to_dm_command(voltage_offset=dm1_voltage_offset)
-        dm2_command = dm2_command_object.to_dm_command(voltage_offset=dm2_voltage_offset)
+        dm1_command = dm1_command_object.to_dm_command()
+        dm2_command = dm2_command_object.to_dm_command()
 
         # Add both arrays together (first half and second half) and send to DM.
         full_command = dm1_command + dm2_command

--- a/catkit/hardware/boston/DmCommand.py
+++ b/catkit/hardware/boston/DmCommand.py
@@ -355,10 +355,14 @@ def add_zernike_to_flat_map(output_path, file_name=None, dm_num=1, zernike_index
     flat_map_volts = get_flat_map_volts(dm_num)
 
     flat_map_volts += (hicat_zernike_module.create_zernike(zernike_index, zernike_coeff_volts) + zernike_coeff_volts/2)
-    flat_map_volts *= catkit.util.get_dm_mask()
+    mask = catkit.util.get_dm_mask().astype('bool')
+    flat_map_volts *= mask
+    flat_map_volts_masked = flat_map_volts[mask]
+    flat_map_volts_masked[flat_map_volts_masked < 0] = 0
+    flat_map_volts[mask] = flat_map_volts_masked
 
     if file_name is None:
-        file_name = f"flat_map_volts_dm_{dm_num}_zernike_{zernike_index}_{zernike_coeff_volts}V.fits"
+        file_name = f"flat_map_volts_dm_{dm_num}_zernike_{zernike_index}_{zernike_coeff_volts:.2f}V.fits"
 
     catkit.util.write_fits(flat_map_volts, os.path.join(output_path, file_name))
 

--- a/catkit/hardware/boston/DmCommand.py
+++ b/catkit/hardware/boston/DmCommand.py
@@ -288,7 +288,6 @@ def convert_dm_image_to_command(dm_image, path_to_save=None):
         catkit.util.write_fits(dm_command, path_to_save)
     return dm_command
 
-
 def create_flatmap_from_dm_command(dm_command_path, output_path, file_name=None, dm_num=1):
     """
     Converts a dm_command_2d.fits to the format used for the flatmap, and outputs a new flatmap fits file.
@@ -313,4 +312,27 @@ def create_flatmap_from_dm_command(dm_command_path, output_path, file_name=None,
     # Convert the dm command units to volts.
     max_volts = CONFIG_INI.getint("boston_kilo952", "max_volts")
     dm_command_data *= max_volts
-    catkit.util.write_fits(dm_command_data, output_path)
+    catkit.util.write_fits(dm_command_data, os.path.join(output_path, file_name))
+
+
+def create_constant_flat_map(output_path, file_name=None, dm_num=1):
+    """
+    Creates a uniform flat map and outputs a new flatmap fits file.
+    :param output_path: Path to output the new flatmap fits file. Default is hardware/boston/
+    :param file_name: Filename for new flatmap fits file. Default is
+            flat_map_volts_dm_<1 or 2>_constant.fits
+    ;param dm_num: Which DM is this for?  Defaults to 1.
+    :return: None
+    """
+    if file_name is None:
+        # Create a string representation of the current timestamp.
+        # time_stamp = time.time()
+        # date_time_string = datetime.datetime.fromtimestamp(time_stamp).strftime("%Y-%m-%dT%H-%M-%S")
+        file_name = "flat_map_volts_dm_" + str(dm_num) + "_constant.fits"
+
+    bias_volts = CONFIG_INI.getint('boston_kilo952', f'bias_volts_dm{dm_num}')
+    mask = catkit.util.get_dm_mask()
+    dm_command_data = mask * bias_volts
+    catkit.util.write_fits(dm_command_data, os.path.join(output_path, file_name))
+
+

--- a/catkit/hardware/boston/DmCommand.py
+++ b/catkit/hardware/boston/DmCommand.py
@@ -111,11 +111,12 @@ class DmCommand(object):
                     flat_map_file_name = CONFIG_INI.get("boston_kilo952", "flat_map_dm1")
                     flat_map_volts = fits.open(os.path.join(self.calibration_data_path, flat_map_file_name))
                     dm_command += flat_map_volts[0].data
-                    # dm_command -= 90
+                    # dm_command -= 30
                 else:
                     flat_map_file_name = CONFIG_INI.get("boston_kilo952", "flat_map_dm2")
                     flat_map_volts = fits.open(os.path.join(self.calibration_data_path, flat_map_file_name))
                     dm_command += flat_map_volts[0].data
+                    # dm_command -= 30
 
             # Convert between 0-1.
             dm_command /= self.max_volts
@@ -336,4 +337,26 @@ def create_constant_flat_map(output_path, file_name=None, dm_num=1):
     dm_command_data = mask * bias_volts
     catkit.util.write_fits(dm_command_data, os.path.join(output_path, file_name))
 
+def add_zernike_to_flat_map(output_path, file_name=None, dm_num=1):
+    """
+    Creates a uniform flat map and outputs a new flatmap fits file.
+    :param output_path: Path to output the new flatmap fits file. Default is hardware/boston/
+    :param file_name: Filename for new flatmap fits file. Default is
+            flat_map_volts_dm_<1 or 2>_constant.fits
+    ;param dm_num: Which DM is this for?  Defaults to 1.
+    :return: None
+    """
+    flat_map = get_flat_map_volts(dm_num)
+
+
+    if file_name is None:
+        # Create a string representation of the current timestamp.
+        # time_stamp = time.time()
+        # date_time_string = datetime.datetime.fromtimestamp(time_stamp).strftime("%Y-%m-%dT%H-%M-%S")
+        file_name = "flat_map_volts_dm_" + str(dm_num) + "_constant.fits"
+
+    bias_volts = CONFIG_INI.getint('boston_kilo952', f'bias_volts_dm{dm_num}')
+    mask = catkit.util.get_dm_mask()
+    dm_command_data = mask * bias_volts
+    catkit.util.write_fits(dm_command_data, os.path.join(output_path, file_name))
 

--- a/catkit/hardware/boston/DmCommand.py
+++ b/catkit/hardware/boston/DmCommand.py
@@ -339,7 +339,7 @@ def create_constant_flat_map(output_path, file_name=None, dm_num=1):
     dm_command_data = mask * bias_volts
     catkit.util.write_fits(dm_command_data, os.path.join(output_path, file_name))
 
-def add_zernike_to_flat_map(output_path, file_name=None, dm_num=1, zernike_index=4, zerike_coeff_volts=10):
+def add_zernike_to_flat_map(output_path, file_name=None, dm_num=1, zernike_index=4, zernike_coeff_volts=10):
     """
     Creates a new flat map from the existing flat map for selected DM by adding a specified Zernike term with the
     specified coefficient magnitude.
@@ -354,8 +354,8 @@ def add_zernike_to_flat_map(output_path, file_name=None, dm_num=1, zernike_index
     """
     flat_map_volts = get_flat_map_volts(dm_num)
 
-    flat_map_volts += hicat_zernike_module.create_zernike(zernike_index, zerike_coeff_volts)
-    flat_map_volts *= mask
+    flat_map_volts += (hicat_zernike_module.create_zernike(zernike_index, zernike_coeff_volts) + zernike_coeff_volts/2)
+    flat_map_volts *= catkit.util.get_dm_mask()
 
     if file_name is None:
         file_name = f"flat_map_volts_dm_{dm_num}_zernike_{zernike_index}_{zernike_coeff_volts}V.fits"

--- a/catkit/hardware/boston/DmCommand.py
+++ b/catkit/hardware/boston/DmCommand.py
@@ -322,16 +322,13 @@ def create_flatmap_from_dm_command(dm_command_path, output_path, file_name=None,
 def create_constant_flat_map(output_path, file_name=None, dm_num=1):
     """
     Creates a uniform flat map and outputs a new flatmap fits file.
-    :param output_path: Path to output the new flatmap fits file. Default is hardware/boston/
+    :param output_path: Path to output the new flatmap fits file.
     :param file_name: Filename for new flatmap fits file. Default is
             flat_map_volts_dm_<1 or 2>_constant.fits
-    ;param dm_num: Which DM is this for?  Defaults to 1.
+    :param dm_num: Which DM is this for?  Defaults to 1.
     :return: None
     """
     if file_name is None:
-        # Create a string representation of the current timestamp.
-        # time_stamp = time.time()
-        # date_time_string = datetime.datetime.fromtimestamp(time_stamp).strftime("%Y-%m-%dT%H-%M-%S")
         file_name = "flat_map_volts_dm_" + str(dm_num) + "_constant.fits"
 
     bias_volts = CONFIG_INI.getint('boston_kilo952', f'bias_volts_dm{dm_num}')
@@ -343,13 +340,13 @@ def add_zernike_to_flat_map(output_path, file_name=None, dm_num=1, zernike_index
     """
     Creates a new flat map from the existing flat map for selected DM by adding a specified Zernike term with the
     specified coefficient magnitude.
-    :param output_path: Path to output the new flatmap fits file. Default is hardware/boston/
+    :param output_path: Path to output the new flatmap fits file.
     :param file_name: Filename for new flatmap fits file. Default is
             flat_map_volts_dm_<1 or 2>_zernike_<zernike index>_<coefficient value>V.fits
-    ;param dm_num: Which DM is this for?  Defaults to 1.
-    ;param zernike_index: What Zernike term are we applying, defaults to 4, which I think is focus, but should update if not
+    :param dm_num: Which DM is this for?  Defaults to 1.
+    :param zernike_index: What Zernike term are we applying, defaults to 4, which I think is focus, but should update if not
     ;param zernike_coeff_volts: Coefficient of the Zernike term that we're adding in volts.  Defaults to +10, which for
-    ;                           most Zernike terms should be a P2V of 20.
+    :                           most Zernike terms should be a P2V of 20.
     :return: None
     """
     flat_map_volts = get_flat_map_volts(dm_num)

--- a/catkit/hardware/boston/DmCommand.py
+++ b/catkit/hardware/boston/DmCommand.py
@@ -113,12 +113,12 @@ class DmCommand(object):
                     flat_map_file_name = CONFIG_INI.get("boston_kilo952", "flat_map_dm1")
                     flat_map_volts = fits.open(os.path.join(self.calibration_data_path, flat_map_file_name))
                     dm_command += flat_map_volts[0].data
-                    # dm_command -= 30
+                    #dm_command -= 15
                 else:
                     flat_map_file_name = CONFIG_INI.get("boston_kilo952", "flat_map_dm2")
                     flat_map_volts = fits.open(os.path.join(self.calibration_data_path, flat_map_file_name))
                     dm_command += flat_map_volts[0].data
-                    # dm_command -= 30
+                    #dm_command -= 60
 
             # Convert between 0-1.
             dm_command /= self.max_volts

--- a/catkit/hardware/boston/DmCommand.py
+++ b/catkit/hardware/boston/DmCommand.py
@@ -111,6 +111,7 @@ class DmCommand(object):
                     flat_map_file_name = CONFIG_INI.get("boston_kilo952", "flat_map_dm1")
                     flat_map_volts = fits.open(os.path.join(self.calibration_data_path, flat_map_file_name))
                     dm_command += flat_map_volts[0].data
+                    # dm_command -= 90
                 else:
                     flat_map_file_name = CONFIG_INI.get("boston_kilo952", "flat_map_dm2")
                     flat_map_volts = fits.open(os.path.join(self.calibration_data_path, flat_map_file_name))

--- a/catkit/hardware/boston/tests/test_DmCommand.py
+++ b/catkit/hardware/boston/tests/test_DmCommand.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from catkit.config import CONFIG_INI
+from catkit.hardware.boston.DmCommand import DmCommand
+
+number_of_actuators = 952
+command_length = 2048
+max_voltage = 200
+
+dm1_bias_voltage = CONFIG_INI.getint('boston_kilo952', 'bias_volts_dm1')
+dm2_bias_voltage = CONFIG_INI.getint('boston_kilo952', 'bias_volts_dm2')
+
+
+@pytest.mark.parametrize("bias", (False, 123))
+def test_non_config_bias_voltages(bias):
+    dm1 = DmCommand(np.zeros(number_of_actuators), dm_num=1, bias=bias).to_dm_command()[:number_of_actuators]*max_voltage
+    dm2 = DmCommand(np.zeros(number_of_actuators), dm_num=2, bias=bias).to_dm_command()[command_length//2:command_length//2+number_of_actuators]*max_voltage
+
+    if bias is False:
+        assert np.allclose(dm1, 0)
+        assert np.allclose(dm2, 0)
+    else:
+        assert np.allclose(dm1, bias)
+        assert np.allclose(dm2, bias)
+
+
+@pytest.mark.parametrize("bias", (None, True))
+def test_config_bias_voltages(bias):
+    dm1 = DmCommand(np.zeros(number_of_actuators), dm_num=1, bias=bias).to_dm_command()[:number_of_actuators]*max_voltage
+    dm2 = DmCommand(np.zeros(number_of_actuators), dm_num=2, bias=bias).to_dm_command()[command_length//2:command_length//2+number_of_actuators]*max_voltage
+
+    if bias is None or bias is True:
+        assert np.allclose(dm1, dm1_bias_voltage)
+        assert np.allclose(dm2, dm2_bias_voltage)
+    else:
+        assert False


### PR DESCRIPTION
Added code in DmCommand to create a flat map with constant voltages or to create a flat map with voltages perturbed by Zernikes.

These are necessary to support determining new flat maps using phase retrieval data in the [HiCAT-687 branch of hicat-package](https://github.com/spacetelescope/hicat-package/tree/HiCAT-687-implement-phase-retrieval-code-on-HiCAT).

Upstream PR for https://github.com/spacetelescope/hicat-package/pull/248