### PR TITLE
Pointing environment.yml to poppy/develop due to poppy release style change.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -41,4 +41,4 @@ dependencies:
     - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
     - hcipy
     - logging-slackhandler
-    - git+https://github.com/spacetelescope/poppy
+    - git+https://github.com/spacetelescope/poppy.git@develop


### PR DESCRIPTION
Detailed in CAKIT-12 (https://jira.stsci.edu/projects/CATKIT/issues/CATKIT-12?filter=allopenissues). We now want to point to poppy/develop, so our environment.yml needs to be updated accordingly.