### PR TITLE
remove testbed_state access in ThorlabsFW102C

### DIFF
--- a/catkit/hardware/thorlabs/ThorlabsFW102C.py
+++ b/catkit/hardware/thorlabs/ThorlabsFW102C.py
@@ -4,7 +4,6 @@ from catkit.config import CONFIG_INI
 from pyvisa import constants
 import time
 
-from catkit.hardware import testbed_state
 from catkit.interfaces.FilterWheel import FilterWheel
 
 
@@ -58,9 +57,7 @@ class ThorlabsFW102C(FilterWheel):
 
         if out[1] == constants.StatusCode.success:
             self.instrument.read()
-
-            # Update testbed state.
-            testbed_state.filter_wheels[self.config_id] = new_position
+            # Wait for wheel to move. Fairly arbitrary 3 s delay...
             time.sleep(3)
         else:
             raise Exception("Filter wheel " + self.config_id + " returned an unexpected response: " + out[1])


### PR DESCRIPTION
See https://github.com/spacetelescope/hicat-package/pull/266

This fairly trivial PR removes setting `testbed_state` for the filter wheel in catkit, as that access is moved into the `testbed.move_filter` function in HICAT in  https://github.com/spacetelescope/hicat-package/pull/266