### PR TITLE
Trigger CI on review requests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: catkit CI
 
 on:
   pull_request:
-    types: [synchronize, review_requested, ready_for_review]
+    types: [review_requested, ready_for_review]
     branches:
     - master
     - develop


### PR DESCRIPTION
Continuation from #95 

In #95 I stupidly misunderstood how the triggers work, they're events, not states, doh!

This means that I don't think we can completely have what I wanted which is no CI for draft PRs.

Instead, we now have to manually trigger the CI by either bumping the PR to "ready for review" if a draft or by manually requesting a review (added in this PR). 🤔  

https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request

The ``synchronize`` event is the one responsible for triggering the CI upon receiving new pushes. Unfortunately, this obviously is still active for draft PRs.

Signed-off-by: James Noss <jnoss@stsci.edu>