### PR TITLE
Adding required flip_mount_id parameter to FlipMotor and ThorlabsMFF101.

### DIFF
--- a/catkit/hardware/thorlabs/ThorlabsMFF101.py
+++ b/catkit/hardware/thorlabs/ThorlabsMFF101.py
@@ -16,10 +16,13 @@ class ThorlabsMFF101(FlipMotor):
 
     def initialize(self, *args, **kwargs):
         """Creates an instance of the controller library and opens a connection."""
-
-        serial = CONFIG_INI.get(self.config_id, "serial")
+        
+        # Write a serial_id key of the form "serial_default" or "serial_pr_mirror"
+        serial_id = f"serial_{self.flip_mount_id}"
+        serial = CONFIG_INI.get(self.config_id, serial_id)
         self.serial = serial
-
+        self.log.info(f'Connecting to flip mount {self.flip_mount_id}, serial # {serial}.')
+        
         # noinspection PyArgumentList
         motor = ftd2xx.openEx(bytes(serial, 'utf-8'))
         motor.setBaudRate(115200)

--- a/catkit/interfaces/FlipMotor.py
+++ b/catkit/interfaces/FlipMotor.py
@@ -7,9 +7,11 @@ import logging
 class FlipMotor(ABC):
     log = logging.getLogger(__name__)
 
-    def __init__(self, config_id, *args, **kwargs):
-        """Opens connection with the motor controller and sets class attributes for 'config_id' and 'motor'."""
+    def __init__(self, config_id, flip_mount_id, *args, **kwargs):
+        """Opens connection with the motor controller and sets class attributes
+        for 'config_id', 'flip_mount_id',  and 'motor'."""
         self.config_id = config_id
+        self.flip_mount_id = flip_mount_id
         self.serial = None
         self.motor = self.initialize(*args, **kwargs)
         self.log.info("Opened connection to flip motor " + config_id)


### PR DESCRIPTION
Addresses https://jira.stsci.edu/browse/HICAT-718 / https://jira.stsci.edu/browse/HICAT-709 to allow for access to multiple flip mounts. 