### PR TITLE
Update axes labels used in NewportMotorController.__update_testbed_state for HICAT-910 relabeling

### DIFF
--- a/catkit/hardware/newport/NewportMotorController.py
+++ b/catkit/hardware/newport/NewportMotorController.py
@@ -43,8 +43,8 @@ class NewportMotorController(MotorController):
                 self.__move_to_nominal(motor_name)
 
         # Update the testbed_state for the FPM and Lyot Stop.
-        self.__update_testbed_state("motor_lyot_stop_x")
-        self.__update_testbed_state("motor_FPM_Y")
+        self.__update_testbed_state("motor_lyot_stop_y")
+        self.__update_testbed_state("motor_FPM_X")
         return myxps
 
     def close(self):


### PR DESCRIPTION
Turns out HICAT-910 requires a small edit in catkit as well. I hadn't realized this but there are a couple hard-coded references to HICAT mechanism labels and config.ini in the `__update_testbed_state` function. 

This PR applies the minimal patch, just swapping X/Y for those axes labels. Pretty sure we both agree that a better long-term fix would be to move this function out of catkit entirely, but that can wait for later. 