### PR TITLE
Add documentation about the IrisAO controls

### DIFF
--- a/catkit/hardware/iris_ao/iris_ao_controller.py
+++ b/catkit/hardware/iris_ao/iris_ao_controller.py
@@ -94,7 +94,7 @@ class IrisAoDmController(DeformableMirrorController):
         return self.instrument
 
     def zero(self, return_zeros=False):
-        """Put zeros on the DM. This does not in general correspond to a flattened DM.
+        """Put zeros on the DM. This does not correspond to a flattened DM.
 
         :return: If return_zeros=True, return a dictionary of zeros
         """


### PR DESCRIPTION
Delta PR to add some minimal documentation to the IrisAO hardware controls in #71, following up on
https://github.com/spacetelescope/instrument-interface-library/pull/71#discussion_r466536405

This will require some changes in the future so I just kept it short.