### PR TITLE
Testing bufix for unit error.

### DIFF
--- a/catkit/hardware/zwo/ZwoCamera.py
+++ b/catkit/hardware/zwo/ZwoCamera.py
@@ -1,7 +1,6 @@
 from astropy.io import fits
 import numpy as np
 import logging
-import os
 import zwoasi
 import sys
 
@@ -218,6 +217,9 @@ class ZwoCamera(Camera):
         """Applies control values found in the config.ini unless overrides are passed in, and does error checking."""
 
         # Load values from config.ini into variables, and override with keyword args when applicable.
+        # Convert exposure time to contain units if not already a Pint quantity.
+        if type(exposure_time) is int or type(exposure_time) is float:
+            exposure_time = quantity(exposure_time, units.microsecond)
         subarray_x = subarray_x if subarray_x is not None else CONFIG_INI.getint(self.config_id, 'subarray_x')
         subarray_y = subarray_y if subarray_y is not None else CONFIG_INI.getint(self.config_id, 'subarray_y')
         width = width if width is not None else CONFIG_INI.getint(self.config_id, 'width')

--- a/catkit/hardware/zwo/ZwoCamera.py
+++ b/catkit/hardware/zwo/ZwoCamera.py
@@ -175,7 +175,8 @@ class ZwoCamera(Camera):
                                     height=height, gain=gain, full_image=full_image, bins=bins)
 
         # Create metadata from testbed_state and add extra_metadata input.
-        meta_data = [MetaDataEntry("Exposure Time", "EXP_TIME", exposure_time.to(units.microseconds).m, "microseconds")]
+        exposure_time = self._strip_units(exposure_time)
+        meta_data = [MetaDataEntry("Exposure Time", "EXP_TIME", exposure_time.to(units.microseconds).magnitude, "microseconds")]
         meta_data.extend(testbed_state.create_metadata())
         meta_data.append(MetaDataEntry("Camera", "CAMERA", self.config_id, "Camera model, correlates to entry in ini"))
         meta_data.append(MetaDataEntry("Gain", "GAIN", self.gain, "Gain for camera"))
@@ -217,7 +218,7 @@ class ZwoCamera(Camera):
             stripped_quantity = nested_quantity
             while has_units and n < 10:
                 stripped_quantity = stripped_quantity.magnitude
-                has_units = 'magnitude' in dir(stripped_quantity)
+                has_units = 'magnitude' in dir(stripped_quantity.magnitude)
                 n += 1
         
         except AttributeError:


### PR DESCRIPTION
As noted by Marshall and Iva, some of our calibration scripts fail because we pick up nested exposure times. 
This introduces a function to strip away all but the bottom layer of units, so that we don't keep trying to pass these nested quantities in.

This problem is also being addressed in https://github.com/spacetelescope/instrument-interface-library/pull/107, but since that has stalled and this continues to be an issue I figured I would throw up this less elegant solution in the meantime. 

This has been tested on hardware, and runs through for `take_sampling_data.py`. 