### PR TITLE
Fix for a minor issue in SNMP exception handling/logging 

### DIFF
--- a/catkit/hardware/SnmpUps.py
+++ b/catkit/hardware/SnmpUps.py
@@ -47,15 +47,10 @@ class SnmpUps(BackupPower):
             else:
                 return result
 
-        except Exception as err:
-            # Most, but not all, exception subclasses have a message attribute. Handle either case.
-            if hasattr(err, 'message'):
-                self.log.exception(err.message)
-            else:
-                self.log.exception(err)
+        except Exception:
+            error_message = f"{self.config_id} SNMP interface request failed."
+            self.log.exception(error_message)
             if return_status_msg:
-                error_message = f"{self.config_id} failed safety test: SNMP interface request failed."
-                self.log.error(error_message)
                 return False, error_message
             else:
                 return False

--- a/catkit/hardware/SnmpUps.py
+++ b/catkit/hardware/SnmpUps.py
@@ -48,7 +48,11 @@ class SnmpUps(BackupPower):
                 return result
 
         except Exception as err:
-            self.log.exception(err.message)
+            # Most, but not all, exception subclasses have a message attribute. Handle either case.
+            if hasattr(err, 'message'):
+                self.log.exception(err.message)
+            else:
+                self.log.exception(err)
             if return_status_msg:
                 error_message = f"{self.config_id} failed safety test: SNMP interface request failed."
                 self.log.error(error_message)


### PR DESCRIPTION
Fix for an exception handling issue encountered while debugging UPS SNMP connection issues on HiCAT. In this case, the exception does not have a '.message' attribute, so trying to access such an attribute raises yet another exception. 

Here's an example of the exception handling that was problematic: 


```
2020-09-08 16:21:42,348 - hicat.experiments.Experiment - INFO - Running safety tests...
2020-09-08 16:21:42,348 - catkit.hardware.SnmpUps - INFO - checking blue_ups SNMP power status
2020-09-08 16:21:48,674 - hicat.experiments.Experiment - ERROR - ('Monitoring process caught an unexpected problem: ', AttributeError("'Exception' object has no attribute 'message'",))
Traceback (most recent call last):
  File "C:\Users\HICAT\repos\instrument-interface-library\catkit\hardware\SnmpUps.py", line 43, in is_power_ok
    status = self.get_status()
  File "C:\Users\HICAT\repos\instrument-interface-library\catkit\hardware\SnmpUps.py", line 34, in get_status
    "Error Status: " + str(error_status))
Exception: Error communicating with the UPS: 'blue_ups'.
Error Indication: No SNMP response received before timeout
Error Status: 0

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\HICAT\repos\hicat-package\hicat\experiments\Experiment.py", line 59, in start
    status, msg = safety_test.check()
  File "C:\Users\HICAT\repos\hicat-package\hicat\experiments\SafetyTest.py", line 45, in check
    is_ok, message = ups.is_power_ok(return_status_msg=True)
  File "C:\Users\HICAT\repos\instrument-interface-library\catkit\hardware\SnmpUps.py", line 51, in is_power_ok
    self.log.exception(err.message)
AttributeError: 'Exception' object has no attribute 'message'
```

With this fix, the SNMP exception gets logged gracefully. 