### PR TITLE
CATKIT-34 Relink instrument-interface-library -> catkit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,7 +93,7 @@ jobs:
         conda env update --name ci-env --file environment2.yml
         conda activate ci-env
         python setup.py develop
-        cd ../instrument-interface-library
+        cd ../catkit
         python setup.py develop
       shell: bash -l {0}
     - name: Test with pytest
@@ -135,7 +135,7 @@ jobs:
         conda env update --name ci-env --file environment2.yml
         conda activate ci-env
         python setup.py develop
-        cd ../instrument-interface-library
+        cd ../catkit
         python setup.py develop
       shell: bash -l {0}
     - name: Test with pytest

--- a/catkit/emulators/boston_dm.py
+++ b/catkit/emulators/boston_dm.py
@@ -75,7 +75,7 @@ class PoppyBmcEmulator:
         # When we're done, leave the simulated DMs in a flat state, to avoid persistent
         # state between different simulation calls.
         # This intentionally differs from hardware behavior in which an unpowered DM is non-flat.
-        # See https://github.com/spacetelescope/instrument-interface-library/issues/63
+        # See https://github.com/spacetelescope/catkit/63
         self.dm1.flatten()
         if self.dm2 is not None:
             self.dm2.flatten()

--- a/catkit/hardware/iris_ao/iris_ao_controller.py
+++ b/catkit/hardware/iris_ao/iris_ao_controller.py
@@ -24,7 +24,7 @@ class IrisAoDmController(DeformableMirrorController):
     will load the PTT values in the file specified with the variable filename_ptt_dm.
 
     Further details can be found in the linked PDF in this comment on GitHub:
-    https://github.com/spacetelescope/instrument-interface-library/pull/71#discussion_r466536405
+    https://github.com/spacetelescope/catkit/pull/71#discussion_r466536405
     """
 
     instrument_lib = subprocess

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup, find_packages
 setup(name='catkit',
       version='0.14.0',
       description='Python API wrapping hardware and device drivers for the Optics Lab.',
-      url='https://github.com/spacetelescope/instrument-interface-library',
+      url='https://github.com/spacetelescope/catkit',
       author='Makidon Optics Lab',
       packages=find_packages())


### PR DESCRIPTION
Those with open catkit PRs (just me) will need to rebase once merged for CI to work.

Signed-off-by: James Noss <jnoss@stsci.edu>