### PR TITLE
Avoid adding None to sys.path, which breaks multiprocessing + pkg_resources

### DIFF
--- a/catkit/hardware/boston/BostonDmController.py
+++ b/catkit/hardware/boston/BostonDmController.py
@@ -9,8 +9,11 @@ from catkit.interfaces.DeformableMirrorController import DeformableMirrorControl
 # BMC is Boston's library and it only works on windows.
 try:
     sdk_path = os.environ.get('CATKIT_BOSTON_SDK_PATH')
-    sys.path.append(sdk_path)
-    import bmc
+    if sdk_path is not None:
+        sys.path.append(sdk_path)
+        import bmc
+    else:
+        bmc = None
 except ImportError:
     bmc = None
 


### PR DESCRIPTION
If `CATKIT_BOSTON_SDK_PATH` is not defined, don't add a `None` to `sys.path`, and don't try to import `bmc`. The presence of a `None` in `sys.path` breaks the `pkg_resources` package when used with multiprocessing. 

Fixes Jacobean calculations in HICAT. 
