### PR TITLE
Delete the todo in set_surface() of the IrisAO emulator, about segment numbering

### DIFF
--- a/catkit/emulators/iris_ao_controller.py
+++ b/catkit/emulators/iris_ao_controller.py
@@ -54,7 +54,7 @@ class PoppyIrisAODM(poppy.dms.HexSegmentedDeformableMirror):
             piston = values[0] * u.um
             tip = values[2] * u.mrad
             tilt = values[1] * u.mrad
-            self.set_actuator(seg-1, piston, tip, tilt)
+            self.set_actuator(seg-1, piston, tip, tilt)    # offset by -1 for 0-based vs 1-based segment indices; see PR #147
 
     @staticmethod
     def invert_data(data):

--- a/catkit/emulators/iris_ao_controller.py
+++ b/catkit/emulators/iris_ao_controller.py
@@ -54,7 +54,7 @@ class PoppyIrisAODM(poppy.dms.HexSegmentedDeformableMirror):
             piston = values[0] * u.um
             tip = values[2] * u.mrad
             tilt = values[1] * u.mrad
-            self.set_actuator(seg-1, piston, tip, tilt)  # TODO: double-check the -1 here, meant to correct for different segment names
+            self.set_actuator(seg-1, piston, tip, tilt)
 
     @staticmethod
     def invert_data(data):


### PR DESCRIPTION
This PR is a follow-up to the question raised here:
https://github.com/spacetelescope/catkit/pull/144#discussion_r518408712

I figured out what was happening here, it was indeed just a matter of segment numbering, as we assumed.

My initial point of confusion was that the `SegmentedDmCommand()` supposedly takes care of the correct segment numbering automatically, through some of the settings in the configfile section for the IrisAO. This proved true, however, in this part of the emulator here, we don't use a `SegmentedDmCommand()` at all. Instead we use a plain dictionary that just spits out a segment numbering going straight from 1 to 37, starting at 1. Poppy's hex DM and its subclasses, like the IrisAO emulator, need a segment list form 0-36 instead though, which is why the -1 was needed in here.

@mperrin I went through making this its own PR just so that we have this noted somewhere where we can look it up - segment numbering issues have been nasty in the past...

We could probably get rid of this random -1 by introducing instances of `SegmentedDmCommand()` in the emulator, but that would require some more work.