### PR TITLE
bug fix: remove some hard-coded imports of hicat files in catkit ZWOCamera and emulator

### DIFF
--- a/catkit/emulators/ZwoCamera.py
+++ b/catkit/emulators/ZwoCamera.py
@@ -2,7 +2,7 @@ import abc
 import logging
 
 import zwoasi
-from hicat.config import CONFIG_INI, CONFIG_MODES
+from catkit.config import CONFIG_INI
 
 import catkit.hardware.zwo.ZwoCamera
 

--- a/catkit/hardware/zwo/ZwoCamera.py
+++ b/catkit/hardware/zwo/ZwoCamera.py
@@ -4,8 +4,8 @@ import sys
 import numpy as np
 import zwoasi
 
-from hicat.config import CONFIG_INI
-from hicat.hardware import testbed_state
+from catkit.config import CONFIG_INI
+from catkit.hardware import testbed_state
 
 
 from catkit.catkit_types import MetaDataEntry, units, quantity


### PR DESCRIPTION
I noticed a couple imports of hicat config and testbed state, presumably left in unintentionally. Switched to imports of the catkit pointers instead. 