### PR TITLE
HICAT-976 Prevent multiple connections

### DIFF
--- a/catkit/interfaces/FlipMotor.py
+++ b/catkit/interfaces/FlipMotor.py
@@ -11,8 +11,12 @@ class FlipMotor(ABC):
         """Opens connection with the motor controller and sets class attributes for 'config_id' and 'motor'."""
         self.config_id = config_id
         self.serial = None
-        self.motor = self.initialize(*args, **kwargs)
         self._keep_alive = False
+        self.instrument = None
+
+        # Connect.
+        self.motor = self.initialize(*args, **kwargs)
+        self.instrument = self.motor
         self.log.info("Opened connection to flip motor " + config_id)
 
     # Implementing context manager.
@@ -22,8 +26,11 @@ class FlipMotor(ABC):
     def __exit__(self, exception_type, exception_value, exception_traceback):
         try:
             if not self._keep_alive:
-                self.close()
-                self.motor = None
+                try:
+                    self.close()
+                finally:
+                    self.motor = None
+                    self.instrument = None
                 self.log.info(f"Safely closed connection to flip motor {self.config_id}")
         finally:
             # Reset, single use basis only.

--- a/catkit/interfaces/Instrument.py
+++ b/catkit/interfaces/Instrument.py
@@ -83,6 +83,11 @@ class Instrument(ABC):
 
     def __open(self):
         # __func() can't be overridden without also overriding those that call it.
+
+        # If instrument is already opened, don't create multiple connections.
+        if self.instrument:
+            return
+
         try:
             self.instrument = self._open()
             self.log.info("Opened connection to '{}'".format(self.config_id))

--- a/catkit/interfaces/LaserSource.py
+++ b/catkit/interfaces/LaserSource.py
@@ -10,8 +10,12 @@ class LaserSource(ABC):
     def __init__(self, config_id, *args, **kwargs):
         """Opens connection with the laser source and sets class attributes for 'config_id'"""
         self.config_id = config_id
-        self.laser = self.initialize(*args, **kwargs)
         self._keep_alive = False
+        self.instrument = None
+
+        # Connect.
+        self.laser = self.initialize(*args, **kwargs)
+        self.instrument = self.laser
         self.log.info("Opened connection to laser source " + config_id)
 
     # Implementing context manager.
@@ -21,8 +25,11 @@ class LaserSource(ABC):
     def __exit__(self, exception_type, exception_value, exception_traceback):
         try:
             if not self._keep_alive:
-                self.close()
-                self.laser = None
+                try:
+                    self.close()
+                finally:
+                    self.laser = None
+                    self.instrument = None
                 self.log.info("Safely closed connection to laser source " + self.config_id)
         finally:
             # Reset, single use basis only.

--- a/catkit/interfaces/MotorController.py
+++ b/catkit/interfaces/MotorController.py
@@ -11,8 +11,12 @@ class MotorController(ABC):
         """Opens connection with the DM and sets class attributes for 'config_id' and 'dm'."""
         self.config_id = config_id
         self.socket_id = None
-        self.motor_controller = self.initialize(*args, **kwargs)
         self._keep_alive = False
+        self.instrument = None
+
+        # Connect.
+        self.motor_controller = self.initialize(*args, **kwargs)
+        self.instrument = self.motor_controller
         self.log.info("Initialized Motor Controller " + config_id)
 
     # Implementing context manager.
@@ -22,8 +26,11 @@ class MotorController(ABC):
     def __exit__(self, exception_type, exception_value, exception_traceback):
         try:
             if not self._keep_alive:
-                self.close()
-                self.motor_controller = None
+                try:
+                    self.close()
+                finally:
+                    self.motor_controller = None
+                    self.instrument = None
                 self.log.info("Safely closed connection to Motor Controller " + self.config_id)
         finally:
             # Reset, single use basis only.


### PR DESCRIPTION
Required by https://github.com/spacetelescope/hicat-package/pull/444 by preventing multiple connections via multiple ``with`` stmnts and adds ``self.instrument`` for those devices not yet a child of ``catkit,interfaces.instrument.Instrument``.

Signed-off-by: James Noss <jnoss@stsci.edu>