### PR TITLE
HICAT-978 Enum API to device cache.

### DIFF
--- a/catkit/conftest.py
+++ b/catkit/conftest.py
@@ -2,16 +2,16 @@ import gc
 
 import pytest
 
-import catkit.testbed
+from catkit.testbed import devices
 
 
 @pytest.fixture(scope="function", autouse=False)
 def derestricted_device_cache():
     # Setup.
-    with catkit.testbed.devices:
+    with devices:
         yield
 
     with pytest.raises(NameError):
-        catkit.testbed.devices["npoint_a"]
+        devices["npoint_a"]
     # Teardown.
     gc.collect()

--- a/catkit/testbed/__init__.py
+++ b/catkit/testbed/__init__.py
@@ -1,3 +1,2 @@
-from catkit.testbed.experiment import devices
-from catkit.testbed.experiment import Experiment
-from catkit.testbed.experiment import SafetyException
+from catkit.testbed.caching import devices, DeviceCacheEnum
+from catkit.testbed.experiment import Experiment, SafetyException

--- a/catkit/testbed/tests/test_testbed.py
+++ b/catkit/testbed/tests/test_testbed.py
@@ -113,3 +113,16 @@ def test_clear(derestricted_device_cache):
 def test_restriction():
     with pytest.raises(NameError):
         catkit.testbed.devices["npoint_a"]
+
+
+def test_DeviceCache():
+    class Dev(catkit.testbed.DeviceCacheEnum):
+        NPOINT_C = ("npoint a for test", "dummy_config_id")
+
+    @catkit.testbed.devices.link(key=Dev.NPOINT_C)
+    def npoint_c():
+        return SimNPointLC400(config_id="npoint_tiptilt_lc_400", com_id="dummy")
+
+    with catkit.testbed.devices:
+        device_c = Dev.NPOINT_C
+        assert device_c.instrument


### PR DESCRIPTION
Upstream PR for https://github.com/spacetelescope/hicat-package/pull/450

Example usage:

```python
from catkit.testbed import devices, DeviceCacheEnum


class Device(DeviceCacheEnum):
  LASER = ("Death Ray", "deathRay3000")
  DM = ("Deformable mirror", "some-config-id")

class TheDeathRay:
  def __init__(config_id, *args, **kwargs):
    self.config_id = config_id

  def fire():
    # Do something lasery

@devices.link(key=Device.LASER)
def laser():
  return TheDeathRay(config_id=Device.LASER.config_id)
 
Device.LASER.fire()

```