### PR TITLE
HICAT-701 Refactor 4D file paths

### DIFF
--- a/catkit/emulators/accufiz.py
+++ b/catkit/emulators/accufiz.py
@@ -1,0 +1,40 @@
+import os
+import requests
+
+from astropy.io import fits
+import h5py
+
+from catkit.hardware.FourDTechnology.Accufiz import Accufiz
+from catkit.interfaces.Instrument import SimInstrument
+
+
+class PoppyAccufizEmulator:
+
+    def __init__(self, optics, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.data = None
+        self.optics = optics
+
+    def get(self, url, params=None, **kwargs):
+        resp = requests.Response()
+        resp.text = "success"
+        return resp
+
+    def post(self, url, data=None, json=None, **kwargs):
+        raise NotImplementedError("TODO: See CATKIT-66.")
+
+        command = os.path.basename(url)
+
+        if command == "AverageMeasure":
+            #self.data = optics.do_stuff()
+        elif command == "SaveMeasurement":
+            filepath = data["fileName"]
+            if self.data is None:
+                raise RuntimeError(f"No data taken to save.")
+            #h5py.write(self.data, f"{filepath}.h5")
+        else:
+            raise NotImplementedError(f"The command '{command}' is not implemented.")
+
+
+class Accufiz(Accufiz, SimInstrument):
+    instrument_lib = PoppyAccufizEmulator

--- a/catkit/emulators/accufiz.py
+++ b/catkit/emulators/accufiz.py
@@ -26,6 +26,7 @@ class PoppyAccufizEmulator:
         command = os.path.basename(url)
 
         if command == "AverageMeasure":
+            pass
             #self.data = optics.do_stuff()
         elif command == "SaveMeasurement":
             filepath = data["fileName"]

--- a/catkit/hardware/FourDTechnology/Accufiz.py
+++ b/catkit/hardware/FourDTechnology/Accufiz.py
@@ -21,19 +21,21 @@ class Accufiz(FizeauInterferometer):
 
     instrument_lib = requests
 
-    def initialize(self, local_path, server_path, mask="dm2_detector.mask", post_save_sleep=1):
+    def initialize(self, local_path, server_path, mask="dm2_detector.mask", post_save_sleep=1, file_mode=True):
         """
 
         :param local_path: str, The local path accessible from Python.
         :param server_path: str, The path accessible from the 4D server.
         :param mask: str, ?
         :param post_save_sleep: int, float, Seconds to sleep between saving and checking for success.
+        :param file_mode: bool, whether to save images to disk.
         """
         self.ip = CONFIG_INI.get(self.config_id, "ip")
         self.timeout = CONFIG_INI.getint(self.config_id, "timeout")
         self.html_prefix = f"http://{self.ip}/WebService4D/WebService4D.asmx"
         self.mask = mask
         self.post_save_sleep = post_save_sleep
+        self.file_mode = file_mode
 
         self.temp_dir = tempfile.TemporaryDirectory()
         self.local_path = os.path.join(local_path, self.temp_dir.name)
@@ -90,7 +92,9 @@ def _open(self):
 
         fits_local_file_path, fits_hdu = self.convert_h5_to_fits(local_file_path, rotate, fliplr)
 
-        if filepath:
+        if self.file_mode:
+            if not filepath:
+                raise ValueError("A filepath is required to write data to disk.")
             shutil.copyfile(fits_local_file_path, filepath)
 
         return fits_hdu

--- a/catkit/hardware/FourDTechnology/Accufiz.py
+++ b/catkit/hardware/FourDTechnology/Accufiz.py
@@ -14,24 +14,24 @@ from scipy import ndimage
 
 from catkit.interfaces.FizeauInterferometer import FizeauInterferometer
 import catkit.util
-from catkit.config import CONFIG_INI
 
 
 class Accufiz(FizeauInterferometer):
 
     instrument_lib = requests
 
-    def initialize(self, local_path, server_path, mask="dm2_detector.mask", post_save_sleep=1, file_mode=True):
+    def initialize(self, ip, local_path, server_path, timeout=60, mask="dm2_detector.mask", post_save_sleep=1, file_mode=True):
         """
-
+        :param ip: str, IP of 4D machine.
         :param local_path: str, The local path accessible from Python.
         :param server_path: str, The path accessible from the 4D server.
+        :param: timeout: int, Timeout for communicating with 4D (seconds).
         :param mask: str, ?
         :param post_save_sleep: int, float, Seconds to sleep between saving and checking for success.
         :param file_mode: bool, whether to save images to disk.
         """
-        self.ip = CONFIG_INI.get(self.config_id, "ip")
-        self.timeout = CONFIG_INI.getint(self.config_id, "timeout")
+        self.ip = ip
+        self.timeout = timeout
         self.html_prefix = f"http://{self.ip}/WebService4D/WebService4D.asmx"
         self.mask = mask
         self.post_save_sleep = post_save_sleep

--- a/catkit/hardware/FourDTechnology/Accufiz.py
+++ b/catkit/hardware/FourDTechnology/Accufiz.py
@@ -15,82 +15,81 @@ from catkit.config import CONFIG_INI
 
 class Accufiz(FizeauInterferometer):
 
-    def initialize(self, mask="dm2_detector.mask", *args, **kwargs):
-        """Opens connection with interferometer and returns the camera manufacturer specific object."""
-        orig = time.time()
-        ip = CONFIG_INI.get(self.config_id, "ip")
-        timeout = CONFIG_INI.getint(self.config_id, "timeout")
+    instrument_lib = requests
 
+    def initialize(self, local_path, server_path, mask="dm2_detector.mask", post_save_sleep=1):
+        """
+
+        :param local_path: str, The local path accessible from Python.
+        :param server_path: str, The path accessible from the 4D server.
+        :param mask: str, ?
+        :param post_save_sleep: int, float, Seconds to sleep between saving and checking for success.
+        """
+        self.ip = CONFIG_INI.get(self.config_id, "ip")
+        self.timeout = CONFIG_INI.getint(self.config_id, "timeout")
+        self.html_prefix = f"http://{self.ip}/WebService4D/WebService4D.asmx"
+        self.local_path = local_path
+        self.server_path = server_path
+        self.mask = mask
+        self.post_save_sleep = post_save_sleep
+
+    def _open(self):
         # Set the 4D timeout.
-        set_timeout_string = "http://{}/WebService4D/WebService4D.asmx/SetTimeout?timeOut={}".format(ip, timeout)
-        requests.get(set_timeout_string)
+        self.set_timeout_string = f"{self.html_prefix}/SetTimeout?timeOut={self.timeout}"
+        self.instrument_lib.get(set_timeout_string)
 
         # Set the Mask. This mask has to be local to the 4D computer in this directory.
-        # filemask = os.path.join("c:\\4Sight_masks", mask)
+        # filemask = os.path.join("c:\\4Sight_masks", self.mask)
         # typeofmask = "Detector"
         # parammask = {"maskType": typeofmask, "fileName": filemask}
         # set_mask_string = "http://{}/WebService4D/WebService4D.asmx/SetMask".format(ip)
         # resmask = requests.post(set_mask_string, data=parammask)
 
-    def close(self):
+        return True  # We're "open".
+
+    def _close(self):
         """Close interferometer connection?"""
+        pass
 
     def take_measurement(self,
-                         path,
                          num_frames=2,
                          filename=None,
                          rotate=0,
                          fliplr=False,
                          exposure_set=""):
 
-        if path is None:
-           raise ValueError("Path must be defined.")
+        # Send request to take data.
+        measurement_resp = self.instrument_lib.post(f"{self.html_prefix}/AverageMeasure", data={"count": int(num_frames)})
+        if "success" not in measurement_resp.text:
+            raise RuntimeError(f"{self.config_id}: Failed to take data - {measurement_resp.text}.")
 
         if filename is None:
             filename = "4d_measurement"
 
-        """Takes exposures and should be able to save fits and simply return the image data."""
-        ip = CONFIG_INI.get(self.config_id, "ip")
-        parammeas = {"count": int(num_frames)}
+        server_file_path = os.path.join(self.server_path, filename)
+        local_file_path = os.path.join(self.local_path, filename)
 
-        try_counter = 0
-        tries = 10
-        while try_counter < tries:
-            measres = requests.post('http://{}/WebService4D/WebService4D.asmx/AverageMeasure'.format(ip), data=parammeas)
+        #  This line is here because when sent through webservice slashes tend
+        #  to disappear. If we sent in parameter a path with only one slash,
+        #  they disappear
+        server_file_path = server_file_path.replace('\\', '/')
+        server_file_path = server_file_path.replace('/', '\\\\')
 
-            pathfile = os.path.join(path, filename)
+        # Create dir.
+        local_path_root = os.path.dirname(local_file_path)
+        if not os.path.exists(local_path_root):
+            os.makedirs(local_path_root)
 
-            #  This line is here because when sent through webservice slashes tend
-            #  to disappear. If we sent in parameter a path with only one slash,
-            #  they disappear
-            pathfile = pathfile.replace('\\',
-                                        '/')
+        # Send request to save data.
+        _resp = self.instrument_lib.post(f"{self.html_prefix}/SaveMeasurement", data={"fileName": server_file_path})
+        time.sleep(self.post_save_sleep)
 
-            pathfile = pathfile.replace('/',
-                                        '\\\\')
+        if not glob(f"{local_file_path}.h5"):
+            raise RunTimeException(f"{self.config_id}: Failed to save measurement data to '{local_file_path}'.")
 
-            paramsave = {"fileName": pathfile}
+        self.log.info(f"{self.config_id}: Succeeded to save measurement data to '{local_file_path}'")
 
-            if 'success' in measres.text:
-                if not os.path.exists(path):
-                    os.makedirs(path)
-                r = requests.post("http://{}/WebService4D/WebService4D.asmx/SaveMeasurement".format(ip), data=paramsave)
-                time.sleep(1)
-                if glob(pathfile + '.h5'):
-                    print('SUCCESS IN SAVING ' + pathfile)
-                    return self.__convert_h5_to_fits(path, pathfile, rotate, fliplr)
-                else:
-                    try_counter += 1
-                    print("FAIL IN SAVING MEASUREMENT " + pathfile + ".h5")
-                    if try_counter < tries:
-                        print("Trying again..")
-            else:
-                try_counter += 1
-                print("FAIL IN MEASUREMENT " + pathfile + ".h5")
-                print(measres.text)
-                if try_counter < tries:
-                    print("Trying again..")
-
+        return self.convert_h5_to_fits(local_file_path, rotate, fliplr)
 
     @staticmethod
     def __get_mask_path(mask):
@@ -101,17 +100,16 @@ class Accufiz(FizeauInterferometer):
         return os.path.join(calibration_data_path, mask)
 
     @staticmethod
-    def __convert_h5_to_fits(path, file, rotate, fliplr):
-        os.chdir(path)
+    def convert_h5_to_fits(filepath, rotate, fliplr, wavelength=632.8):
 
-        file = file if file.endswith(".h5") else file + ".h5"
-        pathfile = file
-        pathdifits = file[:-3] + '.fits'
+        filepath = filepath if filepath.endswith(".h5") else f"{filepath}.h5"
 
-        maskinh5 = np.array(h5py.File(pathfile, 'r').get('measurement0').get('Detectormask'))
-        image0 = np.array(h5py.File(pathfile, 'r').get('measurement0').get('genraw').get('data')) * maskinh5
+        fits_filepath = f"{os.path.splitext(filepath)[0]}.fits"
 
-        fits.PrimaryHDU(maskinh5).writeto(pathdifits, overwrite=True)
+        maskinh5 = np.array(h5py.File(filepath, 'r').get('measurement0').get('Detectormask'))
+        image0 = np.array(h5py.File(filepath, 'r').get('measurement0').get('genraw').get('data')) * maskinh5
+
+        fits.PrimaryHDU(maskinh5).writeto(fits_filepath, overwrite=True)
 
         radiusmask = np.int(np.sqrt(np.sum(maskinh5) / math.pi))
         center = ndimage.measurements.center_of_mass(maskinh5)
@@ -122,8 +120,8 @@ class Accufiz(FizeauInterferometer):
         # Apply the rotation and flips.
         image = catkit.util.rotate_and_flip_image(image, rotate, fliplr)
 
-        # Convert waves to nanometers (wavelength of 632.8).
-        image = image * 632.8
+        # Convert waves to nanometers.
+        image = image * wavelength
 
-        fits.PrimaryHDU(image).writeto(pathdifits, overwrite=True)
-        return pathdifits
+        fits.PrimaryHDU(image).writeto(fits_filepath, overwrite=True)
+        return fits_filepath

--- a/catkit/hardware/FourDTechnology/Accufiz.py
+++ b/catkit/hardware/FourDTechnology/Accufiz.py
@@ -41,9 +41,9 @@ class Accufiz(FizeauInterferometer):
         self.local_path = os.path.join(local_path, self.temp_dir.name)
         self.server_path = os.path.join(server_path, self.temp_dir.name)
 
-def _open(self):
+    def _open(self):
         # Set the 4D timeout.
-        self.set_timeout_string = f"{self.html_prefix}/SetTimeout?timeOut={self.timeout}"
+        set_timeout_string = f"{self.html_prefix}/SetTimeout?timeOut={self.timeout}"
         self.instrument_lib.get(set_timeout_string)
 
         # Set the Mask. This mask has to be local to the 4D computer in this directory.

--- a/catkit/interfaces/FizeauInterferometer.py
+++ b/catkit/interfaces/FizeauInterferometer.py
@@ -1,34 +1,11 @@
-
 from abc import ABC, abstractmethod
+
+from catkit.interfaces.Instrument import Instrument
 
 """Abstract base class for all Fizeau Interferometers. Implementations of this class also become context managers."""
 
 
-class FizeauInterferometer(ABC):
-    def __init__(self, config_id, *args, **kwargs):
-        """Opens connection with camera sets class attributes for 'config_id'"""
-        self.config_id = config_id
-        self.interferometer = self.initialize(*args, **kwargs)
-        print("Opened connection to Fizeau Interferometer: " + self.config_id)
-
-    # Implementing context manager.
-    def __enter__(self, *args, **kwargs):
-        return self
-
-    def __exit__(self, exception_type, exception_value, exception_traceback):
-        self.close()
-        self.interferometer = None
-        print("Safely closed Fizeau Interferometer: " + self.config_id)
-
-    # Abstract Methods.
+class FizeauInterferometer(Instrument, ABC):
     @abstractmethod
-    def initialize(self, *args, **kwargs):
-        """Opens connection with interferometer and returns the camera manufacturer specific object."""
-
-    @abstractmethod
-    def close(self):
-        """Close interferometer connection."""
-
-    @abstractmethod
-    def take_measurement(self, num_frames, path, filename):
+    def take_measurement(self, num_frames, filename):
         """Takes exposures and should be able to save fits and simply return the image data."""


### PR DESCRIPTION
Upstream PR for https://github.com/spacetelescope/hicat-package/pull/475.

- [ ] Test
- [x] Lay foundation for emulator.
- [ ] Complete emulator (possible punt). See [CATKIT-66](https://jira.stsci.edu/browse/CATKIT-66).
- [x] The passing of ``output_path`` to the 4D code seems to suggest that the caller assumed that the 4D data was written there, yet the code doesn't do such a thing. However, it does raise the question of whether the 4D data needs to be persisted, e.g., copied to an experiment dir? This then raises the question of...
- [x] Use temp files for 4D data comm but copy as noted above?
- [x] Return fits HDU

Signed-off-by: James Noss <jnoss@stsci.edu>