### PR TITLE
HICAT-294 Interface with IrisAO C/C++ API

### DIFF
--- a/catkit/hardware/iris_ao/iris_ao_controller.py
+++ b/catkit/hardware/iris_ao/iris_ao_controller.py
@@ -1,13 +1,12 @@
 """Interface for IrisAO segmented deformable mirror controller."""
 
 import os
-import signal
-import subprocess
 import time
+
+import IrisAO_Python
 
 from catkit.interfaces.DeformableMirrorController import DeformableMirrorController
 from catkit.hardware.iris_ao.segmented_dm_command import SegmentedDmCommand
-
 from catkit.hardware.iris_ao import util
 
 
@@ -29,7 +28,7 @@ class IrisAoDmController(DeformableMirrorController):
     https://github.com/spacetelescope/catkit/pull/71#discussion_r466536405
     """
 
-    instrument_lib = subprocess
+    instrument_lib = IrisAO_Python
 
     def initialize(self,
                    mirror_serial,
@@ -69,38 +68,59 @@ class IrisAoDmController(DeformableMirrorController):
         # Where to write ConfigPTT.ini file that gets read by the C++ code
         self.filename_ptt_dm = filename_ptt_dm
 
-    def send_data(self, data):
+        # Determine filename paths for calibration/config files.
+        self.config_file_dir_path = os.path.abspath(config_file_dir_path)
+        if not os.path.isdir(self.config_file_dir_path):
+            raise FileNotFoundError(f"{self.config_id}: config_file_dir_path: '{self.config_file_dir_path}' not found.")
+        self.mirror_config_file_path = os.path.join(self.config_file_dir_path, self.mirror_serial + self.mirror_config_file_ext)
+        self.driver_config_file_path = os.path.join(self.config_file_dir_path, self.driver_serial + self.driver_config_file_ext)
+        if not os.path.isFile(self.mirror_config_file_path):
+            raise FileNotFoundError(f"{self.config_id}: '{self.mirror_config_file_path}' not found.")
+        if not os.path.isFile(self.driver_config_file_path):
+            raise FileNotFoundError(f"{self.config_id}: '{self.driver_config_file_path}' not found.")
+
+        # The IrisAO driver expects the .dcf and .mcf config files in the working dir.
+        # Neither adding them to PATH nor PYTHONPATH worked.
+        # This is a workaround.
+        # These files remain copied until their refs go out of scope, i.e., when this class instance drops out of scope.
+        cwd = os.path.abspath(os.getcwd())
+        self._mirror_config_file_copy = catkit.util.TempFileCopy(self.mirror_config_file_path, cwd)
+        self._driver_config_file_copy = catkit.util.TempFileCopy(self.driver_config_file_path, cwd)
+
+    def _send_data(self, data):
         """
         To send data to the IrisAO, you must write to the ConfigPTT.ini file
         to send the command
 
         :param data: dict, the command to be sent to the DM
         """
-        # Write to ConfigPTT.ini
-        self.log.info("Creating config file: %s", self.filename_ptt_dm)
-        util.write_ini(data, path=self.filename_ptt_dm, dm_config_id=self.config_id,
-                       mirror_serial=self.mirror_serial,
-                       driver_serial=self.driver_serial)
+        if not self.instrument:
+            raise Exception(f"{self.config_id}: Open connection required.")
 
-        # Apply the written .ini file to DM
-        self.instrument.stdin.write(b'config\n')
-        self.instrument.stdin.flush()
+        if not isinstance(data, dict):
+            raise TypeError(f"{self.config_id}: expected 'data' to be a dict and not '{type(data)}'.")
+
+        segments = list(data.keys())
+        ptt = list(data.values())
+
+        if len(segments) != len(ptt):
+            raise TypeError(f"{self.config_id}: Corrupt data - each segment must have a corresponding PTT and vice versa.")
+
+        try:
+            self.instrument_lib._setPosition(self.instrument, segments, len(segments), ptt)
+        except Exception as error:
+            raise Exception(f"{self.config_id}: Failed to send command data to device.") from error
 
     def _open(self):
         """Open a connection to the IrisAO"""
-        cmd = [self.full_path_dm_exe, str(self.disable_hardware)]
-        if self.path_to_custom_mirror_files:
-            cmd.append(self.path_to_custom_mirror_files)
-        if self.filename_ptt_dm:
-            cmd.append(self.filename_ptt_dm)
-
-        self.instrument = self.instrument_lib.Popen(cmd,
-                                                    stdin=self.instrument_lib.PIPE, stdout=self.instrument_lib.PIPE,
-                                                    stderr=self.instrument_lib.PIPE,
-                                                    cwd=self.path_to_dm_exe,
-                                                    bufsize=1,
-                                                    creationflags=self.instrument_lib.CREATE_NEW_PROCESS_GROUP)
-        time.sleep(1)
+        hardware_enabled = not self.disable_hardware
+        try:
+            self.instrument = self.instrument_lib._connect(self.mirror_serial.encode(),
+                                                           self.driver_serial.encode(),
+                                                           hardware_enabled)
+        except Exception as error:
+            self.instrument = None  # Don't try closing
+            raise Exception(f"{self.config_id}: Failed to connect to device.") from error
 
         # Initialize the Iris to zeros.
         self.zero()
@@ -123,23 +143,39 @@ class IrisAoDmController(DeformableMirrorController):
     def _close(self):
         """Close connection safely."""
         try:
-            self.log.info('Closing Iris AO.')
-            # Since sending "quit" kills the proc a race condition exits between it quiting and a close() as it may
-            # exit before close() is called and thus cause close() to raise. This can even be true for an explicit call
-            # to stdin.flush() if the write buffer auto flushes.
-            # The above can leave the device hanging and unreachable. The safest option is to send the following signal
-            # which is gracefully handled on the C++ side.
-
-            #self.instrument.send_signal(signal.CTRL_C_EVENT)
-
-            # However, the above no longer seems to work, see HICAT-948 & HICAT-947.
-            self.instrument.stdin.write(b'quit\n')
             try:
-                self.instrument.stdin.flush()
-            except Exception:
-                pass
+                # Set IrisAO to zero
+                self.zero()
+            finally:
+                self.instrument_lib._release(self.instrument)
         finally:
             self.instrument = None
+            self._close_iris_controller_testbed_state()
+
+    def get_position(self, segments=None):
+        """ Read the PTT for the given segments from the device itself. """
+
+        if not self.instrument:
+            raise Exception(f"{self.config_id}: Open connection required.")
+
+        segments = segments if segments else iris_util.iris_pupil_numbering(self.num_segments)
+
+        # _getMirrorPosition() expects a list of segments
+        if not isinstance(segments, collections.Iterable):
+            segments = [segments]
+
+        if isinstance(segments, np.ndarray):
+            segments = segments.tolist()
+
+        try:
+            ptt, _locked, _reachable = self.instrument_lib._getMirrorPosition(self.instrument, segments, len(segments))
+        except Exception as error:
+            raise Exception(f"{self.config_id}: Failed to get command data from device.") from error
+
+        if len(segments) != len(ptt):
+            raise TypeError(f"{self.config_id}: Corrupt data - each segment must have a corresponding PTT and vice versa.")
+
+        return SegmentedDmCommand(dict(zip(segments, ptt)), flat_map=False)
 
     def apply_shape(self, dm_shape, dm_num=1):
         """
@@ -153,11 +189,14 @@ class IrisAoDmController(DeformableMirrorController):
         if dm_num != 1:
             raise NotImplementedError("You can only control one Iris AO at a time")
 
+        if not isinstance(dm_shape, SegmentedDmCommand):
+            raise TypeError(f"{self.config_id}: expected 'dm_shape' to be of type `{SegmentedDmCommand.__qualname__}' and not '{type(dm_shape)}'.")
+
         # Use DmCommand class to format the single command correctly.
-        command = dm_shape.to_command()
+        command_dict = dm_shape.to_command()
 
         # Send array to DM.
-        self.send_data(command)
+        self._send_data(command_dict)
 
         # Update the dm_command class attribute.
         self.command_object = dm_shape

--- a/catkit/hardware/iris_ao/iris_ao_controller.py
+++ b/catkit/hardware/iris_ao/iris_ao_controller.py
@@ -41,7 +41,9 @@ class IrisAOCLib:
         self._SetMirrorPosition.restype = None
         self._SetMirrorPosition.argtypes = [ctypes.c_char_p, ctypes.c_uint, ctypes.c_float, ctypes.c_float, ctypes.c_float]
 
-    def MirrorCommand(self, mirror, command=self.instrument_lib.MirrorSendSettings):
+    def MirrorCommand(self, mirror, command=None):
+        if command is None:
+            command = self.instrument_lib.MirrorSendSettings
         return self._MirrorConnect(mirror, command)
 
     def MirrorConnect(self, mirror_serial, driver_serial, disabled):

--- a/catkit/hardware/iris_ao/iris_ao_controller.py
+++ b/catkit/hardware/iris_ao/iris_ao_controller.py
@@ -13,7 +13,6 @@ class IrisAOCLib:
     def __init__(self, dll_filepath):
         self.dll_filepath = dll_filepath
         self.dll = None
-        self.positions_initiated = False
 
         if not self.dll:
             try:
@@ -42,14 +41,8 @@ class IrisAOCLib:
         self._SetMirrorPosition.restype = None
         self._SetMirrorPosition.argtypes = [ctypes.c_char_p, ctypes.c_uint, ctypes.c_float, ctypes.c_float, ctypes.c_float]
 
-    def MirrorCommand(self, mirror):
-        if self.positions_initiated:
-            return self._MirrorConnect(mirror, self.instrument_lib.MirrorSendSettings)
-        else:
-            # TODO: What's the diff?
-            ret = self._MirrorConnect(mirror, self.instrument_lib.MirrorInitSettings)
-            self.positions_initiated = True
-            return ret
+    def MirrorCommand(self, mirror, command=self.instrument_lib.MirrorSendSettings):
+        return self._MirrorConnect(mirror, command)
 
     def MirrorConnect(self, mirror_serial, driver_serial, disabled):
         return self._MirrorConnect(mirror_serial, driver_serial, disabled)
@@ -168,7 +161,7 @@ class IrisAoDmController(DeformableMirrorController):
             raise Exception(f"{self.config_id}: Failed to connect to device.") from error
 
         # Initialize the Iris to zeros.
-        self.zero()
+        self.instrument_lib.MirrorCommand(self.instrument, command=self.instrument_lib.MirrorInitSettings)
 
         return self.instrument
 

--- a/catkit/util.py
+++ b/catkit/util.py
@@ -224,3 +224,41 @@ def soft_kill(process):
             log.info("Child process softly killed.")
         except KeyboardInterrupt:
             log.exception("Main process: caught ctrl-c")
+
+
+class TempFileCopy:
+    def __init__(self, source, destination):
+        self.own = False  # If the copy was successful we own it to delete it.
+
+        if not os.path.isfile(source):
+            raise ValueError(f"The source path '{source}' must be a file")
+        self.source = os.path.abspath(source)
+
+        if os.path.isdir(destination):
+            destination = os.path.join(destination, os.path.basename(self.source))
+        self.destination = os.path.abspath(destination)
+
+        self._copy()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        self._delete()
+
+    def __del__(self):
+        self._delete()
+
+    def _copy(self):
+        shutil.copyfile(self.source, self.destination)
+        self.own = True
+
+    def _delete(self):
+        if not self.own:
+            return
+
+        try:
+            if os.path.exists(self.destination):
+                os.remove(self.destination)
+        finally:
+            self.own = False

--- a/catkit/util.py
+++ b/catkit/util.py
@@ -1,14 +1,15 @@
 import importlib
-import os
 import logging
 import logging.handlers
+import os
 import signal
+import shutil
 import time
-from catkit.catkit_types import MetaDataEntry
 
 import numpy as np
 from astropy.io import fits
 
+from catkit.catkit_types import MetaDataEntry
 from catkit.catkit_types import quantity
 
 


### PR DESCRIPTION
Resolves [HICAT-294](https://jira.stsci.edu/browse/HICAT-294) and relates to [HICAT-714](https://jira.stsci.edu/browse/HICAT-714).

Moved from #70

- [ ] Tested on hicta1 with spare.
- [ ] Tested on hicta2.
- [ ] Downstream hicat-package changes.
- [ ] Downstream jost-package changes.

https://github.com/spacetelescope/iris-ao
Turns out that we had the 64b lib all along 😬  😆  

Loading the following dll works. I haven't tested anything beyond that yet. https://github.com/spacetelescope/iris-ao/blob/vendor-installation-disk-v1.0.2.5a/Iris%20AO%20Installation%20Disk%20v1.0.2.5a/API/C-C%2B%2B%20Source%20Code%20%26%20Libraries/x64/IrisAO.Devices.dll

Signed-off-by: James Noss <jnoss@stsci.edu>