### PR TITLE
HICAT-1014 Improved IrisAO subprocess error handling 

### DIFF
--- a/catkit/emulators/iris_ao_controller.py
+++ b/catkit/emulators/iris_ao_controller.py
@@ -134,6 +134,14 @@ class PoppyIrisAOEmulator:
     def flush(self):
         pass
 
+    def readline(self):
+        return b"success"
+
+    def poll(self):
+        pass
+
+    def wait(self, timeout=None):
+        pass
 
 class PoppyIrisAoDmController(SimInstrument, IrisAoDmController):
     instrument_lib = PoppyIrisAOEmulator

--- a/catkit/hardware/iris_ao/iris_ao_controller.py
+++ b/catkit/hardware/iris_ao/iris_ao_controller.py
@@ -76,6 +76,8 @@ class IrisAoDmController(DeformableMirrorController):
 
         :param data: dict, the command to be sent to the DM
         """
+        self.raise_on_error()
+
         # Write to ConfigPTT.ini
         self.log.info("Creating config file: %s", self.filename_ptt_dm)
         util.write_ini(data, path=self.filename_ptt_dm, dm_config_id=self.config_id,
@@ -85,6 +87,7 @@ class IrisAoDmController(DeformableMirrorController):
         # Apply the written .ini file to DM
         self.instrument.stdin.write(b'config\n')
         self.instrument.stdin.flush()
+        self.raise_on_error()
 
     def _open(self):
         """Open a connection to the IrisAO"""
@@ -106,6 +109,11 @@ class IrisAoDmController(DeformableMirrorController):
         self.zero()
 
         return self.instrument
+
+    def raise_on_error(self):
+        error = self.instrument.stderr.read()
+        if error:
+            raise RuntimeError(error)
 
     def zero(self, return_zeros=False):
         """Put zeros on the DM. This does not correspond to a flattened DM.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='catkit',
-      version='0.25.0',
+      version='0.26.0',
       description='Python API wrapping hardware and device drivers for the Optics Lab.',
       url='https://github.com/spacetelescope/catkit',
       author='Makidon Optics Lab',


### PR DESCRIPTION
- [x] Update emulator.

 Changes due to https://github.com/spacetelescope/hicat-package/pull/490

What we want:

* To read ``stdout`` and ``stderr``, however, we need to do so with a timeout for when there's nothing to read otherwise it will deadlock waiting for data that will never come.

What doesn't work:

 * ``subprocess.communicate()``, this is a single-use func and closes everything upon return.
 * `` select.select()``, doesn't work on Windows for pipes (I even tried just in case). 😭 

``select.select()`` seems to be the only python way to do this, which means we might have to abandon this.

The C++ https://github.com/spacetelescope/hicat-package/pull/490 removes all writes to ``stdout`` other than errors and "success" messages. Code here now reads these "success" messages. There is still scope for the deadlock of an indefinite read, however, I guess this is better than nothing. 🤷   