### PR TITLE
Make jamienoss default global codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-/catkit/hardware/iris_ao/ @kjbrooks
+* @jamienoss
+/catkit/hardware/iris_ao/ @kjbrooks @jamienoss


### PR DESCRIPTION
Signed-off-by: James Noss <jnoss@stsci.edu>