### PR TITLE
CATKIT-79: vmin and vmax in segmented DM command display()

### DIFF
--- a/catkit/hardware/iris_ao/segmented_dm_command.py
+++ b/catkit/hardware/iris_ao/segmented_dm_command.py
@@ -338,7 +338,7 @@ class SegmentedDmCommand(object):
         :param filename: str, name of ini file to be written out
         :param out_dir: str, name of directory where ini file will be saved
         """
-        if not filename.endswith((".ini", ".ini")):
+        if not filename.endswith(".ini"):
             filename += ".ini"
 
         data = self.get_data()

--- a/catkit/hardware/iris_ao/segmented_dm_command.py
+++ b/catkit/hardware/iris_ao/segmented_dm_command.py
@@ -358,7 +358,7 @@ class SegmentedDmCommand(object):
                                           f"Piston/GradX/GradY applied for segment {seg}"))
         return metadata
 
-    def display(self, display_wavefront=True, display_psf=True, psf_rotation_angle=0.,
+    def display(self, display_wavefront=True, display_psf=True, psf_rotation_angle=0., vmax_opd=0.5e-6*u.meter, vmin_psf=1e-8, vmax_psf=1e-2,
                 save_figures=True, figure_name_prefix='', out_dir=''):
         """
         Display either the deployed mirror state ("wavefront") and/or the PSF created
@@ -390,12 +390,12 @@ class SegmentedDmCommand(object):
         if figure_name_prefix:
             figure_name_prefix = f'{figure_name_prefix}_'
         if display_wavefront:
-            self.plot_wavefront(figure_name_prefix, out_dir, save_figure=save_figures)
+            self.plot_wavefront(figure_name_prefix, out_dir, vmax=vmax_opd, save_figure=save_figures)
         if display_psf:
-            self.plot_psf(rotation_angle=psf_rotation_angle, figure_name_prefix=figure_name_prefix, out_dir=out_dir,
+            self.plot_psf(rotation_angle=psf_rotation_angle, vmin=vmin_psf, vmax=vmax_psf, figure_name_prefix=figure_name_prefix, out_dir=out_dir,
                           save_figure=save_figures)
 
-    def plot_wavefront(self, figure_name_prefix, out_dir, vmax=0.5e-6*u.meter, save_figure=True):
+    def plot_wavefront(self, figure_name_prefix, out_dir, vmax, save_figure=True):
         """
         Plot the deployed mirror state (wavefront error)
 

--- a/catkit/hardware/iris_ao/segmented_dm_command.py
+++ b/catkit/hardware/iris_ao/segmented_dm_command.py
@@ -416,9 +416,9 @@ class SegmentedDmCommand(object):
             plt.show()
 
     @poppy.utils.quantity_input(display_wavelength=u.nm)   # decorator provides a check on input units
-    def plot_psf(self, wavelength=640*u.nm, figure_name_prefix=None, rotation_angle=0,  out_dir=None, vmin=10e-8,
+    def plot_psf(self, wavelength=640*u.nm, figure_name_prefix=None, rotation_angle=0,  out_dir=None, vmin=1e-8,
                  pixelscale=0.010, instrument_fov=1.0,
-                 vmax=10e-2, save_figure=True):
+                 vmax=1e-2, save_figure=True):
         """
         Plot the simulated PSF based on the mirror state. Optionally save figure to a file as well
 

--- a/catkit/hardware/iris_ao/segmented_dm_command.py
+++ b/catkit/hardware/iris_ao/segmented_dm_command.py
@@ -395,7 +395,7 @@ class SegmentedDmCommand(object):
             self.plot_psf(rotation_angle=psf_rotation_angle, vmin=vmin_psf, vmax=vmax_psf, figure_name_prefix=figure_name_prefix, out_dir=out_dir,
                           save_figure=save_figures)
 
-    def plot_wavefront(self, figure_name_prefix, out_dir, vmax, save_figure=True):
+    def plot_wavefront(self, figure_name_prefix, out_dir, vmax=0.5e-6*u.meter, save_figure=True):
         """
         Plot the deployed mirror state (wavefront error)
 

--- a/catkit/hardware/iris_ao/segmented_dm_command.py
+++ b/catkit/hardware/iris_ao/segmented_dm_command.py
@@ -338,6 +338,9 @@ class SegmentedDmCommand(object):
         :param filename: str, name of ini file to be written out
         :param out_dir: str, name of directory where ini file will be saved
         """
+        if not filename.endswith((".ini", ".ini")):
+            filename += ".ini"
+
         data = self.get_data()
         command = dict(zip(self.segments_in_pupil, data))
         path = os.path.join(out_dir, filename)


### PR DESCRIPTION
[CATKIT-79](https://jira.stsci.edu/browse/CATKIT-79)

Pass the plotting parameters `vmin` and `vmax` through the display method of the segmented DM command. Only `vmax` for OPD, both `vmin`and `vmax` for PSF.

I also made it not required anymore to include the file ending .ini when writing a command to an ini file.

@kjbrooks I believe you used to have issues with the PSF plotting, this should give you more control over it.