### PR TITLE
Add reversed sign based on poppy version in piston too

### DIFF
--- a/catkit/emulators/iris_ao_controller.py
+++ b/catkit/emulators/iris_ao_controller.py
@@ -54,7 +54,7 @@ class PoppyIrisAODM(poppy.dms.HexSegmentedDeformableMirror):
             # Furthermore, depending on poppy version we may need to correct a sign inconsistency
             sign = -1 if Version(poppy.__version__) < Version('1.0') else 1
 
-            piston = values[0] * u.um
+            piston = sign * values[0] * u.um
             tip = sign * values[2] * u.mrad
             tilt = sign * values[1] * u.mrad
             self.set_actuator(seg-1, piston, tip, tilt)    # offset by -1 for 0-based vs 1-based segment indices; see PR #147


### PR DESCRIPTION
Follow-up to #187 

If we assume poppy to be consistent within itself, which it is, we will also need a sign inversion in piston when passing IrisAO commands to the emulator, this PR adds that, in the same way like for the tip/tilt commands.

@ehpor was running dOTF experiments on HiCAT with which we could confirm this.