### PR TITLE
CATKIT-91 Fix numpy size compatibility issue.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,7 +68,7 @@ jobs:
       max-parallel: 1
       matrix:
         python-version: [3.7]
-        os: [windows-latest, ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
       with:
@@ -110,7 +110,7 @@ jobs:
       max-parallel: 1
       matrix:
         python-version: [3.7]
-        os: [windows-latest, ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,16 +84,7 @@ jobs:
       run: |
         sed -E 's/[ \t]*-[ \t]*python[=<>0-9.,]*/  - python=${{ matrix.python-version }}/' environment.yml > environment2.yml
         conda env create --name ci-env --file environment2.yml
-        cd ../
-        git clone https://${{secrets.GITHUB_USER}}:${{secrets.TOKEN}}@github.com/spacetelescope/hicat-package
-        cd hicat-package
-        git checkout develop
-        git describe --dirty --long
-        sed -E 's/[ \t]*-[ \t]*python[=<>0-9.,]*/  - python=${{ matrix.python-version }}/' environment.yml > environment2.yml
-        conda env update --name ci-env --file environment2.yml
         conda activate ci-env
-        python setup.py develop
-        cd ../catkit
         python setup.py develop
       shell: bash -l {0}
     - name: Test with pytest

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@
 name: catkit
 dependencies:
   - astropy>=1.3
-  - numpy==1.16.6
+  - numpy==1.17.5
   - conda-forge::pyusb
   - flake8
   - h5py

--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,6 @@ dependencies:
   - scipy
   - sphinx
   - pip:
-    - zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
-    - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
-    - hcipy
-    - git+https://github.com/spacetelescope/poppy.git@v0.9.2
+    - --no-binary
+    - --no-build-isolation
+    - -r file:requirements.txt

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - flake8
   - h5py
   - matplotlib
-  - conda-forge::photutils==0.7.2
+  - http://ssb.stsci.edu/astroconda::photutils==0.7.2
   - pip
   - psutil
   - pyserial

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - flake8
   - h5py
   - matplotlib
-  - conda-forge::photutils==1.0.2
+  - conda-forge::photutils==1.0.1
   - pip
   - psutil
   - pyserial

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - flake8
   - h5py
   - matplotlib
-  - conda-forge::photutils==1.0.1
+  - conda-forge::photutils==1.0.0
   - pip
   - psutil
   - pyserial

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,17 @@
 
 name: catkit
 dependencies:
+  - cryptography=3.3.1
+  - flake8=3.8.4
+  - hypothesis=6.6.1
+  - importlib-metadata=2.0.0
+  - importlib_metadata=2.0.0
+  - libtiff=4.1.0
+  - sphinx=3.5.2
+  - sqlite=3.33.0
+  - toml=0.10.1
+  - zipp=3.4.0
+  - zope.interface=5.2.0
   - conda-forge::astropy>=1.3
   - conda-forge::numpy>=1.15.0  # See CATKIT-91
   - conda-forge::numexpr  # See CATKIT-91

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,8 @@ dependencies:
   - scipy
   - sphinx
   - pip:
+    - --no-binary
+    - --no-build-isolation
     - zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
     - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
     - hcipy

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,12 @@ dependencies:
   - conda-forge::pyvisa>=1.10
   - conda-forge::pyvisa-py
   - requests
+  - scikit-image>=0.17
   - scipy
   - sphinx
   - pip:
-    - -r file:requirements.txt
+    - zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
+    - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
+    - hcipy
+    - git+https://github.com/spacetelescope/poppy.git@v0.9.2
+    - photutils==1.0.2

--- a/environment.yml
+++ b/environment.yml
@@ -10,8 +10,8 @@
 name: catkit
 dependencies:
   - astropy>=1.3
-  - numpy>=1.15.0
-  - numexpr  # See CATKIT-91
+  - conda-forge::numpy>=1.15.0  # See CATKIT-91
+  - conda-forge::numexpr  # See CATKIT-91
   - conda-forge::pyusb
   - flake8
   - future  # See CATKIT-91
@@ -27,7 +27,7 @@ dependencies:
   - conda-forge::pyvisa>=1.10
   - conda-forge::pyvisa-py
   - requests
-  - scipy
+  - conda-forge::scipy  # See CATKIT-91
   - sphinx
   - conda-forge::xxhash  # See CATKIT-91
   - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -9,26 +9,13 @@
 
 name: catkit
 dependencies:
-  - cryptography=3.3.1
-  - flake8=3.8.4
-  - hypothesis=6.6.1
-  - importlib-metadata=2.0.0
-  - importlib_metadata=2.0.0
-  - libtiff=4.1.0
-  - sphinx=3.5.2
-  - sqlite=3.33.0
-  - toml=0.10.1
-  - zipp=3.4.0
-  - zope.interface=5.2.0
-  - conda-forge::astropy>=1.3
-  - conda-forge::numpy>=1.20.0  # See CATKIT-91
-  - conda-forge::numexpr  # See CATKIT-91
+  - astropy>=1.3
+  - numpy>=1.15.0
   - conda-forge::pyusb
   - flake8
-  - future  # See CATKIT-91
   - h5py
   - matplotlib
-  - conda-forge::photutils=1.0.2  # See CATKIT-91
+  - conda-forge::photutils
   - pip
   - psutil
   - pyserial
@@ -38,9 +25,8 @@ dependencies:
   - conda-forge::pyvisa>=1.10
   - conda-forge::pyvisa-py
   - requests
-  - conda-forge::scipy  # See CATKIT-91
+  - scipy
   - sphinx
-  - conda-forge::xxhash  # See CATKIT-91
   - pip:
     - zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
     - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@
 
 name: catkit
 dependencies:
-  - astropy>=1.3
+  - conda-forge::astropy>=1.3
   - conda-forge::numpy>=1.15.0  # See CATKIT-91
   - conda-forge::numexpr  # See CATKIT-91
   - conda-forge::pyusb

--- a/environment.yml
+++ b/environment.yml
@@ -11,8 +11,10 @@ name: catkit
 dependencies:
   - astropy>=1.3
   - numpy>=1.15.0
+  - numexpr  # See CATKIT-91
   - conda-forge::pyusb
   - flake8
+  - future  # See CATKIT-91
   - h5py
   - matplotlib
   - conda-forge::photutils
@@ -27,6 +29,7 @@ dependencies:
   - requests
   - scipy
   - sphinx
+  - conda-forge::xxhash  # See CATKIT-91
   - pip:
     - zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
     - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - zipp=3.4.0
   - zope.interface=5.2.0
   - conda-forge::astropy>=1.3
-  - conda-forge::numpy>=1.19.2  # See CATKIT-91
+  - conda-forge::numpy>=1.20.0  # See CATKIT-91
   - conda-forge::numexpr  # See CATKIT-91
   - conda-forge::pyusb
   - flake8

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@
 name: catkit
 dependencies:
   - astropy>=1.3
-  - numpy>=1.15.0
+  - numpy==1.16.6
   - conda-forge::pyusb
   - flake8
   - h5py

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - zipp=3.4.0
   - zope.interface=5.2.0
   - conda-forge::astropy>=1.3
-  - conda-forge::numpy>=1.15.0  # See CATKIT-91
+  - conda-forge::numpy>=1.19.2  # See CATKIT-91
   - conda-forge::numexpr  # See CATKIT-91
   - conda-forge::pyusb
   - flake8

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - flake8
   - h5py
   - matplotlib
-  - conda-forge::photutils
+  - conda-forge::photutils==1.0.2
   - pip
   - psutil
   - pyserial

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - future  # See CATKIT-91
   - h5py
   - matplotlib
-  - conda-forge::photutils
+  - conda-forge::photutils=1.0.2  # See CATKIT-91
   - pip
   - psutil
   - pyserial

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,6 @@ dependencies:
   - flake8
   - h5py
   - matplotlib
-  - http://ssb.stsci.edu/astroconda::photutils==0.7.2
   - pip
   - psutil
   - pyserial
@@ -28,6 +27,7 @@ dependencies:
   - scipy
   - sphinx
   - pip:
+    - photutils
     - zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
     - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
     - hcipy

--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,4 @@ dependencies:
   - scipy
   - sphinx
   - pip:
-    - --no-binary
-    - --no-build-isolation
     - -r file:requirements.txt

--- a/environment.yml
+++ b/environment.yml
@@ -10,12 +10,12 @@
 name: catkit
 dependencies:
   - astropy>=1.3
-  - numpy>=1.20.0
+  - numpy>=1.15.0
   - conda-forge::pyusb
   - flake8
   - h5py
   - matplotlib
-  - conda-forge::photutils
+  - conda-forge::photutils=1.0.2
   - pip
   - psutil
   - pyserial

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,6 @@ dependencies:
   - flake8
   - h5py
   - matplotlib
-  - conda-forge::photutils
   - pip
   - psutil
   - pyserial

--- a/environment.yml
+++ b/environment.yml
@@ -27,8 +27,4 @@ dependencies:
   - scipy
   - sphinx
   - pip:
-    - photutils
-    - zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
-    - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
-    - hcipy
-    - git+https://github.com/spacetelescope/poppy.git@v0.9.2
+    - -r file:requirements.txt

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - flake8
   - h5py
   - matplotlib
+  - conda-forge::photutils
   - pip
   - psutil
   - pyserial
@@ -32,4 +33,3 @@ dependencies:
     - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
     - hcipy
     - git+https://github.com/spacetelescope/poppy.git@v0.9.2
-    - photutils==1.1.0

--- a/environment.yml
+++ b/environment.yml
@@ -28,8 +28,6 @@ dependencies:
   - scipy
   - sphinx
   - pip:
-    - --no-binary
-    - --no-build-isolation
     - zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
     - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
     - hcipy

--- a/environment.yml
+++ b/environment.yml
@@ -10,12 +10,12 @@
 name: catkit
 dependencies:
   - astropy>=1.3
-  - numpy==1.17.5
+  - numpy>=1.15.0,<1.20
   - conda-forge::pyusb
   - flake8
   - h5py
   - matplotlib
-  - conda-forge::photutils
+  - conda-forge::photutils==1.0.2
   - pip
   - psutil
   - pyserial

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - flake8
   - h5py
   - matplotlib
-  - conda-forge::photutils==1.0.0
+  - conda-forge::photutils==0.7.2
   - pip
   - psutil
   - pyserial

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - flake8
   - h5py
   - matplotlib
-  - conda-forge::photutils=1.0.2
+  - conda-forge::photutils
   - pip
   - psutil
   - pyserial

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - flake8
   - h5py
   - matplotlib
+  - conda-forge::photutils
   - pip
   - psutil
   - pyserial
@@ -27,4 +28,7 @@ dependencies:
   - scipy
   - sphinx
   - pip:
-    - -r file:requirements.txt
+    - zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
+    - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
+    - hcipy
+    - git+https://github.com/spacetelescope/poppy.git@v0.9.2

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@
 name: catkit
 dependencies:
   - astropy>=1.3
-  - numpy>=1.15.0
+  - numpy>=1.20.0
   - conda-forge::pyusb
   - flake8
   - h5py

--- a/environment.yml
+++ b/environment.yml
@@ -32,4 +32,4 @@ dependencies:
     - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
     - hcipy
     - git+https://github.com/spacetelescope/poppy.git@v0.9.2
-    - photutils==1.0.2
+    - photutils==1.1.0

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,6 @@ dependencies:
   - flake8
   - h5py
   - matplotlib
-  - conda-forge::photutils==1.0.2
   - pip
   - psutil
   - pyserial
@@ -32,4 +31,5 @@ dependencies:
     - zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
     - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
     - hcipy
+    - photutils
     - git+https://github.com/spacetelescope/poppy.git@v0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-- --no-binary :all:
-- photutils
 - zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
 - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
 - hcipy
 - git+https://github.com/spacetelescope/poppy.git@v0.9.2
+- photutils --install-option="--no-binary :all:"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
---no-binary :all:
-zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
-ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
-hcipy
-git+https://github.com/spacetelescope/poppy.git@v0.9.2
-git+https://github.com/astropy/photutils.git@1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--no-binary :all:
 zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
 ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
 hcipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://as
 ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
 hcipy
 git+https://github.com/spacetelescope/poppy.git@v0.9.2
+git+https://github.com/astropy/photutils.git@1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
+ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
+hcipy
+git+https://github.com/spacetelescope/poppy.git@v0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 - ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
 - hcipy
 - git+https://github.com/spacetelescope/poppy.git@v0.9.2
-- photutils --install-option="--no-binary :all:"
+- photutils==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-- zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
-- ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
-- hcipy
-- git+https://github.com/spacetelescope/poppy.git@v0.9.2
-- photutils==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+- --no-binary :all:
+- photutils
+- zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://astronomy-imaging-camera.com/software-drivers
+- ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
+- hcipy
+- git+https://github.com/spacetelescope/poppy.git@v0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ zwoasi>=0.0.21 # Requires additional manual install of driver(s) from https://as
 ftd2xx # Requires additional manual install of driver from https://www.ftdichip.com/Drivers/D2XX.htm
 hcipy
 git+https://github.com/spacetelescope/poppy.git@v0.9.2
-git+https://github.com/astropy/photutils.git@1.2.0
+git+https://github.com/astropy/photutils.git@1.0.2


### PR DESCRIPTION
Summary (ignoring chaos and stupidity):

numpy 1.20 added stuff to the ndarray C struct which changed its size. This results in a compatibility issue with some compiled code, e.g., like that in photutils, throwing the error:
```python
E   ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject
```

1. catkit CI runs its tests and hicat's in separate CI jobs, however, the catkit-only tests were still using the hicat env which caused me to waste a day chasing my own tail.
2. photutils 1.1.0 (rel March 20) from conda-forge seems to be built against numpy 1.20 (which is our issue)
3. photutils 1.0.2 (rel Jan 20) was not and works. This is what we were using before when tests passed, along with numpy 1.19.2.
4. Both of these versions work when obtained from pip (even as bin wheels) so we're doing this hoping never to encounter this issue until we _need_ numpy >= 1.20.
5. Our numpy dep is now ``>=1.15.0,<1.20``.
6. Downstream catkit tests of hicat will fail until this is reflected in the hicat environment.yml also.
 
Signed-off-by: James Noss <jnoss@stsci.edu>