### PR TITLE
HICAT-1083: Take exposures with a generator function

### DIFF
--- a/catkit/hardware/zwo/ZwoCamera.py
+++ b/catkit/hardware/zwo/ZwoCamera.py
@@ -167,10 +167,10 @@ class ZwoCamera(Camera):
         timeout : Pint quantity
             How long to wait for an image. Afterwards a timeout exception is raised.
 
-        Returns
+        Yields
         -------
-        images : list of (np.array of floats)
-            All captured images in a list.
+        image : np.array of floats
+            Each of the captured images.
         """
         timeout_in_ms = timeout.to(units.millisecond).magnitude
         images = []
@@ -180,15 +180,14 @@ class ZwoCamera(Camera):
         try:
             for i in range(num_exposures):
                 img = self.instrument.capture_video_frame(timeout=timeout_in_ms)
+                img = img.astype(np.dtype(np.float32))
 
-                images.append(img.astype(np.dtype(np.float32)))
+                yield img
         finally:
             # Stop exposures. The stop_exposure() might not be necessary, but there's no
             # harm in calling it anyway.
             self.instrument.stop_video_capture()
             self.instrument.stop_exposure()
-
-        return images
 
     def __capture_video_and_orient(self, num_exposures, timeout, theta, fliplr):
         """ Takes a number of images and flips each according to theta and l/r input.
@@ -206,16 +205,13 @@ class ZwoCamera(Camera):
         fliplr : bool
             Whether to flip left/right.
 
-        Returns
+        Yields
         -------
-        images : list of (np.array of floats)
-            All captured images in a list.
+        image : np.array of floats
+            Each captured image.
         """
-        images = self.__capture_video(num_exposures, timeout)
-
-        oriented_images = [catkit.util.rotate_and_flip_image(unflipped_image, theta, fliplr) for unflipped_image in images]
-
-        return oriented_images
+        for img in self.__capture_video(num_exposures, timeout):
+            yield catkit.util.rotate_and_flip_image(img, theta, fliplr)
 
     def _close(self):
         """Close camera connection"""
@@ -229,14 +225,18 @@ class ZwoCamera(Camera):
                        subarray_x=None, subarray_y=None, width=None, height=None, gain=None, full_image=None,
                        bins=None):
         """ Wrapper to take exposures and also save them if `file_mode` is used. """
+        images = []
+        meta = None
 
-        images, meta = self.just_take_exposures(exposure_time=exposure_time,
-                                                num_exposures=num_exposures,
-                                                extra_metadata=extra_metadata,
-                                                full_image=full_image, subarray_x=subarray_x, subarray_y=subarray_y,
-                                                width=width, height=height,
-                                                gain=gain,
-                                                bins=bins)
+        for img, meta in self.just_take_exposures(exposure_time=exposure_time,
+                                                  num_exposures=num_exposures,
+                                                  extra_metadata=extra_metadata,
+                                                  full_image=full_image, subarray_x=subarray_x, subarray_y=subarray_y,
+                                                  width=width, height=height,
+                                                  gain=gain,
+                                                  bins=bins):
+            images.append(img)
+            meta = meta
 
         if file_mode:
             catkit.util.save_images(images, meta, path=path, base_filename=filename, raw_skip=raw_skip)
@@ -296,15 +296,14 @@ class ZwoCamera(Camera):
             # SDK recommends 2 x exposure time + 0.5sec, but we want to never trigger the timeout accidentally.
             timeout = 2 * exposure_time + quantity(10, units.second) # ms
 
-            img_list = self.__capture_video_and_orient(num_exposures, timeout, theta=self.theta, fliplr=self.fliplr)
+            for img in self.__capture_video_and_orient(num_exposures, timeout, theta=self.theta, fliplr=self.fliplr):
+                yield img, meta_data
         else:
-            img_list = []
             # Take exposures and add to list.
             for i in range(num_exposures):
                 img = self.__capture_and_orient(initial_sleep=exposure_time, theta=self.theta, fliplr=self.fliplr)
-                img_list.append(img)
 
-        return img_list, meta_data
+                yield img, meta_data
 
     def flash_id(self, new_id):
         """

--- a/catkit/interfaces/Camera.py
+++ b/catkit/interfaces/Camera.py
@@ -7,5 +7,9 @@ from catkit.interfaces.Instrument import Instrument
 class Camera(Instrument, ABC):
 
     @abstractmethod
-    def take_exposures(self, exposure_length, num_exposures, path=None, filename=None, *args, **kwargs):
+    def take_exposures(self, exposure_time, num_exposures, path=None, filename=None, *args, **kwargs):
         """Takes exposures and should be able to save fits and simply return the image data."""
+
+    @abstractmethod
+    def stream_exposures(self, exposure_time, num_exposures, *args, **kwargs):
+        """ Take a stream of exposures and yield individual images (ie. a generator)."""


### PR DESCRIPTION
My original plan was to add a `as_generator=False` keyword argument to the `just_take_exposures()` function of the `ZwoCamera`. However, if you have a yield statement in a Python function, even if that yield statement is never executed, the function is still converted to a generator function. Therefore, return statements behave differently, and the original function cannot be used anymore. There are two options left:

* Create a separate generator function that actually takes the exposures, and call that function from `just_take_exposures()`, which then just wraps the images into a list and returns those. This has little impact on existing code, but adds yet another function for taking exposures, which is what we spent a lot of time on to avoid.
* Second option is to convert `just_take_exposures()` into a generator function, and deal with downstream effects. Not a lot of our code is actually calling `just_take_exposures()` directly, so this is by far not as bad as it sounds. This enforces the distinction between `take_exposures()` and `just_take_exposures()` where the latter is meant as a lower-level method of the two.

~I went with the second option for now, as the end result is cleaner.~ I actually went for the first option; see reasons below.

- [x] Hardware tests