### PR TITLE
add reversed sign based on poppy version in piston too

### DIFF
--- a/catkit/emulators/iris_ao_controller.py
+++ b/catkit/emulators/iris_ao_controller.py
@@ -54,7 +54,7 @@ class PoppyIrisAODM(poppy.dms.HexSegmentedDeformableMirror):
             # Furthermore, depending on poppy version we may need to correct a sign inconsistency
             sign = -1 if Version(poppy.__version__) < Version('1.0') else 1
 
-            piston = values[0] * u.um
+            piston = sign * values[0] * u.um
             tip = sign * values[2] * u.mrad
             tilt = sign * values[1] * u.mrad
             self.set_actuator(seg-1, piston, tip, tilt)    # offset by -1 for 0-based vs 1-based segment indices; see PR #147

--- a/catkit/hardware/iris_ao/segmented_dm_command.py
+++ b/catkit/hardware/iris_ao/segmented_dm_command.py
@@ -494,6 +494,9 @@ def round_ptt_list(ptt_list, decimals=3):
 
 
 def convert_ptt_units(ptt_list, tip_factor, tilt_factor, starting_units, ending_units):
+    # TODO: this should follow the logic from here: https://github.com/spacetelescope/catkit/blob/8c1e22e8f96d51f4453bba27c4710d27da5d37c5/catkit/emulators/iris_ao_controller.py#L50
+    # This is used in display, where it's not super important, and it's used in the global Zernike commands, so those
+    # are not super reliable at this point.
     """
     Convert the PTT list to or from Poppy units and the segmented DM units.
 


### PR DESCRIPTION
Reopened from #216 (reverted in #231) due to subsequent CI failures in #228 and #230.

See https://github.com/spacetelescope/catkit/runs/2470296681

Signed-off-by: James Noss <jnoss@stsci.edu>