### PR TITLE
HICAT-793 Add shared memory management functionality

### DIFF
--- a/catkit/multiprocessing.py
+++ b/catkit/multiprocessing.py
@@ -1,0 +1,274 @@
+from collections import namedtuple
+import os
+import threading
+
+# NOTE: "multiprocess" is a 3rd party package and not Python's own "multiprocessing".
+# https://github.com/uqfoundation/multiprocess is a fork of multiprocessing that uses "dill" instead of "pickle".
+from multiprocess import get_context, get_logger, TimeoutError
+from multiprocess.managers import AcquirerProxy, BarrierProxy, Namespace, NamespaceProxy, State, \
+    SyncManager, ValueProxy
+
+
+DEFAULT_TIMEOUT = 60
+DEFAULT_SHARED_MEMORY_SERVER_ADDRESS = ("127.0.0.1", 6000)  # IP, port.
+
+CONTEXT_METHOD = "spawn"
+CONTEXT = get_context(CONTEXT_METHOD)
+
+
+class Process(CONTEXT.Process):
+    def run(self):
+        """ Catch exception on child process and save in shared memory manager for parent to read.
+            This is executed on the child process.
+        """
+        try:
+            super().run()
+        except Exception as error:
+            try:  # Manager may not have been started.
+                manager = SharedMemoryManager()
+                manager.connect()
+                manager.set_exception(self.pid, error)
+            finally:
+                raise error
+
+    def join(self):
+        """ Join and raise saved exception if one occurred.
+            This is executed on the parent process.
+        """
+        super().join()
+        if self.exitcode:
+            exception = None
+            try:  # Manager may not have been started. TODO: possibly remove this.
+                manager = SharedMemoryManager()
+                manager.connect()
+                exception = manager.get_exception(self.pid)
+            except Exception:
+                 pass
+            if exception:
+                raise exception
+
+
+class Mutex:
+    """ A container for a shared re-entrant lock.
+
+        NOTE: For this to be actually shared it is subsequently registered with
+        catkit.multirocessing.SharedMemoryManager and must be instantiated from a running/connected instance of
+        catkit.multirocessing.SharedMemoryManager.
+    """
+
+    def __init__(self, *args, lock=None, timeout=DEFAULT_TIMEOUT, **kwargs):
+        super().__init__(*args, **kwargs)
+        lock = threading.RLock() if lock is None else lock
+        self.lock = lock.lock if isinstance(lock, Mutex) else lock
+        self.timeout = timeout
+
+    def acquire(self, timeout=None, raise_on_fail=True):
+        """
+            https://docs.python.org/3/library/multiprocessing.html#multiprocessing.RLock
+            The parent semantics for `timeout=None` := timeout=infinity. We have zero use case for this and, instead,
+            will use `self.timeout` if `timeout is None`.
+        """
+        if timeout is None:
+            timeout = self.timeout
+
+        locked = self.lock.acquire(timeout=timeout)
+        if raise_on_fail and not locked:
+            raise TimeoutError(f"Failed to acquire lock after {timeout}s")
+        return locked
+
+    def release(self):
+        return self.lock.release()
+
+    def __enter__(self):
+        return self.acquire()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return self.release()
+
+    class Proxy(AcquirerProxy):
+        def acquire(self, *args, **kwargs):
+            return self._callmethod('acquire', args, kwargs)  # Don't unpack.
+
+
+class MutexedSingletonNamespace:
+
+    """ A child of the above Mutex and multiprocess.managers.Namespace implemented as a singleton.
+
+    The singleton pattern allows for namespaces to be created on the shared memory server AND be accessed from any
+    client without needing a reference to its proxy but instead, just the registered name.
+
+     Whilst multiprocessing.managers facilitate shared memory (even across networks) any object stored on the server
+     is only accessible via its proxy instance. No proxy object, no access. Furthermore, the server object gets
+     deleted when no longer referenced by a proxy. This means that access across processes requires you to still
+     pass the proxy through from the parent to the child processes. Two ways to create something more persistent
+     and more universally accessible are the following:
+
+        1) Create a subclass of the manager with the addition of a new attribute that will be instantiated on the
+           server and and accessible via registered funcs.
+           As exampled by catkit.multiprocessing.SharedMemoryManager.cache_lock.
+        2) Create a subclass of MutexedSingletonNamespace and register it such that the registered
+           TypeID will be the universal ID accessible from any client.
+           As exampled by catkit.multiprocessing.SharedMemoryManager().shared_state().
+    """
+
+    instance = None
+
+    # Namespace.__init__() takes only **kwargs so we're forced to use this inheritance order (not that it would matter).
+    class _MutexedSingletonNamespace(Mutex, Namespace):
+        pass
+
+    def __new__(cls, *args, **kwargs):
+        if not cls.instance:
+            cls.instance = cls._MutexedSingletonNamespace(*args, **kwargs)
+        return cls.instance
+
+    # __getattr__ & __setattr__ should explicitly NOT be mutexed as reentrant locks are only reentrant from the same
+    # process and these will get executed server-side, which would cause a timeout/deadlock.
+    def __getattr__(self, name):
+        return self.instance.__getattribute__(name)
+
+    def __setattr__(self, name, value):
+        return object.__setattr__(self.instance, name, value)
+
+    # Proxy (client-side) access needs to be mutexed though the mutex doesn't belong to the proxy instance but the
+    # server-side referent. The manager mutexes access on the server, however, we wish to expose a mutex to the client
+    # such that multiple accesses can be mutexed.
+    class Proxy(Mutex.Proxy, NamespaceProxy):
+        _exposed_ = ('__getattribute__', '__setattr__', '__delattr__', 'acquire', 'release')
+
+        # Copied from NamespaceProxy (with added mutex).
+        def __getattr__(self, key):
+            if key[0] == '_':
+                return object.__getattribute__(self, key)
+            try:
+                locked = None
+                locked = object.__getattribute__(self, "__enter__")()
+                callmethod = object.__getattribute__(self, '_callmethod')
+                return callmethod('__getattribute__', (key,))
+            finally:
+                if locked:
+                    object.__getattribute__(self, "__exit__")(None, None, None)
+
+        def __setattr__(self, key, value):
+            if key[0] == '_':
+                return object.__setattr__(self, key, value)
+            try:
+                locked = None
+                locked = object.__getattribute__(self, "__enter__")()
+                callmethod = object.__getattribute__(self, '_callmethod')
+                return callmethod('__setattr__', (key, value))
+            finally:
+                if locked:
+                    object.__getattribute__(self, "__exit__")(None, None, None)
+
+        def __delattr__(self, key):
+            if key[0] == '_':
+                return object.__delattr__(self, key)
+            try:
+                locked = None
+                locked = object.__getattribute__(self, "__enter__")()
+                callmethod = object.__getattribute__(self, '_callmethod')
+                return callmethod('__delattr__', (key,))
+            finally:
+                if locked:
+                    object.__getattribute__(self, "__exit__")(None, None, None)
+
+
+class SharedMemoryManager(SyncManager):
+    """
+    Managers can be connected to from any process using SharedMemoryManager(address=<address>).connect().
+    They therefore don't have to be passed to child processes, when created, from the parent.
+    However, SyncManager.RLock() is a factory and has no functionality to return the same locks thus requiring
+    locks to still be passed to the child processes, when created, from the parent.
+    This class solves this issue by caching mutexes (and barriers) on the server.
+
+    NOTE: Registrations need to occur before the server is started.
+
+    Parameters
+    ----------
+    address : tuple
+        A tuple of the following `(IP, port)` to start the shared server on.
+    timeout : float, int
+        Default timeout for mutexing access.
+    own : bool
+        If True, shutdown() will get called upon deletion.
+    """
+
+    def __init__(self, *args, address=DEFAULT_SHARED_MEMORY_SERVER_ADDRESS, timeout=DEFAULT_TIMEOUT, own=False, **kwargs):
+        super().__init__(*args, address=address, **kwargs)
+        self.log = get_logger()
+        self.server_pid = None
+        self.own = own
+
+        # Server-side non-shared non-reentrant lock to protect against any possible server-side threading.
+        self.master_lock = Mutex(lock=threading.Lock(), timeout=timeout)
+
+        self.lock_cache = {}  # Cache for all locks (local dummy - don't access directly).
+        self.barrier_cache = {}  # Cache for all barriers (local dummy - don't access directly).
+        self.child_process_exceptions = {}  # Used to pass exceptions back to parent.
+
+        # Nothing is stored in the above (local) instances, they are copied to the server and must then be accessed by
+        # the following registered funcs.
+
+        def get_lock(name, timeout=DEFAULT_TIMEOUT):
+            # NOTE: This is registered below and will get executed server-side.
+            with self.master_lock:
+                if name not in self.lock_cache:
+                    self.lock_cache.update({name: Mutex(lock=threading.RLock(), timeout=timeout)})
+                return self.lock_cache.get(name)
+
+        def get_barrier(name, parties, action=None, timeout=DEFAULT_TIMEOUT):
+            # NOTE: This is registered below and will get executed server-side.
+            with self.master_lock:
+                if name not in self.barrier_cache:
+                    self.barrier_cache.update({name: threading.Barrier(parties=parties,
+                                                                       action=action,
+                                                                       timeout=timeout)})
+                return self.barrier_cache.get(name)
+
+        # Registered funcs get executed server side.
+        self.register("_getpid", callable=os.getpid, proxytype=ValueProxy)  # This will return the PID of the server.
+        self.register("get_lock", callable=get_lock, proxytype=Mutex.Proxy)
+        self.register("get_barrier", callable=get_barrier, proxytype=BarrierProxy)
+
+        def set_exception(pid, exception):
+            self.child_process_exceptions[pid] = exception
+
+        self.register("set_exception", callable=set_exception)
+        self.register("_get_exception", callable=lambda pid: self.child_process_exceptions.get(pid), proxytype=ValueProxy)
+
+    def getpid(self):
+        return self._getpid()._getvalue()
+
+    def get_exception(self, pid):
+        return self._get_exception(pid)._getvalue()
+
+    def start(self, *args, **kwargs):
+        ret = super().start(*args, **kwargs)
+        self.server_pid = self.getpid()
+        self.log.info(f"Shared memory manager started on PID: '{self.server_pid}'")
+        return ret
+
+    def shutdown(self):
+        # Whilst super().shutdown() can be called multiple times, the method doesn't even exist until
+        # the server is started and will thus raise an AttributeError when not.
+        if self._state.value == State.STARTED:  # NOTE: ``State`` is not an enum.
+            return super().shutdown()
+
+    def __del__(self):
+        if self.own:
+            self.shutdown()
+        if getattr(super(), "__del__", None):
+            super().__del__()
+
+
+SharedMemoryManager.register("Mutex", callable=Mutex, proxytype=Mutex.Proxy)
+
+
+class SharedState(MutexedSingletonNamespace):
+    pass
+
+
+# Then make the above namespace object `SharedState` accessible from any client via
+# `SharedMemoryManager().connect().SharedState()`:
+SharedMemoryManager.register("SharedState", callable=SharedState, proxytype=SharedState.Proxy)

--- a/catkit/multiprocessing.py
+++ b/catkit/multiprocessing.py
@@ -45,7 +45,7 @@ class Process(CONTEXT.Process):
             except Exception:
                  pass
             if exception:
-                raise exception
+                raise Exception(f"Exception raised on process '{self.name}' (PID: {self.pid})") from exception
 
 
 class Mutex:

--- a/catkit/multiprocessing.py
+++ b/catkit/multiprocessing.py
@@ -39,20 +39,20 @@ class Process(CONTEXT.Process):
         if not self.exitcode:
             return
 
-        exception = Exception(f"Child process ('{self.name}' with pid: '{self.pid}') exited with non-zero exitcode: '{self.exitcode}'")
-
         child_exception = None
         try:  # Manager may not have been started.
             manager = SharedMemoryManager()
             manager.connect()
-            exception = manager.get_exception(self.pid)
+            child_exception = manager.get_exception(self.pid)
         except Exception:
              pass
 
         if child_exception:
-            raise exception from child_exception
+            # Raise the child exception rather than chaining, to facilitate better options for subsequent exception
+            # handling.
+            raise child_exception
         else:
-            raise exception
+            raise Exception(f"Child process ('{self.name}' with pid: '{self.pid}') exited with non-zero exitcode: '{self.exitcode}'")
 
 
 class Mutex:

--- a/catkit/testbed/caching.py
+++ b/catkit/testbed/caching.py
@@ -31,7 +31,7 @@ class ContextCache(UserCache):
         pass
 
     def __delitem__(self, key):
-        if getattr(self.data[key], "__exit__", None):
+        if hasattr(self.data[key], "__exit__"):
             try:
                 self.data[key].__exit__(None, None, None)
             except Exception:

--- a/catkit/testbed/experiment.py
+++ b/catkit/testbed/experiment.py
@@ -106,7 +106,7 @@ class Experiment(ABC):
 
             self.log.info("Creating separate process to run experiment...")
             # Spin off and start the process to run the experiment.
-            experiment_process = Process(target=self.run_experiment)
+            experiment_process = Process(target=self.run_experiment, name=self.name)
             experiment_process.start()
             self.log.info(self.name + " process started")
 
@@ -151,7 +151,7 @@ class Experiment(ABC):
             safety_exception = SafetyException("Monitoring process caught an unexpected problem: ", e)
             self.log.exception(safety_exception)
             # Shut down the experiment (but allow context managers to exit properly).
-            if experiment_process is not None:
+            if experiment_process is not None and experiment_process.is_alive():
                 catkit.util.soft_kill(experiment_process)
             # must return SafetyException type specifically to signal queue to stop in typical calling scripts
             raise safety_exception

--- a/catkit/testbed/experiment.py
+++ b/catkit/testbed/experiment.py
@@ -138,9 +138,6 @@ class Experiment(ABC):
                     # Experiment ended before the next check interval, exit the while loop.
                     break
                     self.log.info("Experment ended before check interval; exiting.")
-
-            # Explicitly join even though experiment_process.is_alive() will call join() if it's no longer alive.
-            experiment_process.join()  # This will raise any child exceptions.
         except KeyboardInterrupt:
             self.log.exception("Parent process: caught ctrl-c, raising exception.")
             raise
@@ -156,9 +153,8 @@ class Experiment(ABC):
             # must return SafetyException type specifically to signal queue to stop in typical calling scripts
             raise safety_exception
 
-        experiment_process.join()
-        if experiment_process.exitcode:
-            raise Exception(f"Child process ('{self.name}' with pid: '{experiment_process.pid}') exited with non-zero exitcode: '{experiment_process.exitcode}'")
+        # Explicitly join even though experiment_process.is_alive() will call join() if it's no longer alive.
+        experiment_process.join()  # This will raise any child exceptions.
 
     def run_experiment(self):
         """

--- a/catkit/testbed/tests/test_shared_state.py
+++ b/catkit/testbed/tests/test_shared_state.py
@@ -1,0 +1,386 @@
+import os
+import psutil
+import time
+import uuid
+
+from astropy.io import fits
+from multiprocess.context import TimeoutError
+from multiprocess.managers import ListProxy
+import numpy as np
+import pytest
+
+from catkit.testbed.caching import SharedState, UserCache
+from catkit.multiprocessing import Process, SharedMemoryManager
+
+TIMEOUT = 5  # Use a shorter timeout for testing.
+
+
+def test_naked_shared_state():
+    def client1_func():
+        manager = SharedMemoryManager()
+        manager.connect()
+        shared_state = manager.SharedState()
+
+        assert shared_state.attribute_from_parent == "from parent"
+
+        shared_state.attribute_from_client1 = "from client1"
+        shared_state.attribute_from_parent = "mutated from client1"
+
+    def client2_func():
+        manager = SharedMemoryManager()
+        manager.connect()
+        shared_state = manager.SharedState()
+
+        assert shared_state.attribute_from_client1 == "from client1"
+        assert shared_state.attribute_from_parent == "mutated from client1"
+
+        shared_state.attribute_from_client2 = "from client2"
+
+    with SharedMemoryManager() as manager:
+        client1 = Process(target=client1_func)
+        client2 = Process(target=client2_func)
+
+        shared_state = manager.SharedState()
+        shared_state.attribute_from_parent = "from parent"
+
+        client1.start()
+        client1.join()
+
+        client2.start()
+        client2.join()
+
+        print(shared_state.attribute_from_client1, shared_state.attribute_from_client2,shared_state.attribute_from_parent)
+
+        assert shared_state.attribute_from_client1 == "from client1"
+        assert shared_state.attribute_from_client2 == "from client2"
+        assert shared_state.attribute_from_parent == "mutated from client1"
+
+
+def test_SharedState():
+    def client1_func():
+        shared_state = SharedState()
+
+        assert shared_state.attribute_from_parent == "from parent"
+
+        shared_state.attribute_from_client1 = "from client1"
+        shared_state.attribute_from_parent = "mutated from client1"
+
+    def client2_func():
+        shared_state = SharedState()
+
+        assert shared_state.attribute_from_client1 == "from client1"
+        assert shared_state.attribute_from_parent == "mutated from client1"
+
+        shared_state.attribute_from_client2 = "from client2"
+
+    client1 = Process(target=client1_func)
+    client2 = Process(target=client2_func)
+
+    shared_state = SharedState(own=True)
+
+    shared_state.attribute_from_parent = "from parent"
+
+    client1.start()
+    client1.join()
+
+    client2.start()
+    client2.join()
+
+    assert shared_state.attribute_from_client1 == "from client1"
+    assert shared_state.attribute_from_client2 == "from client2"
+    assert shared_state.attribute_from_parent == "mutated from client1"
+
+
+def test_shutdown():
+    shared_state = SharedState(own=True)
+    server_pid = shared_state._manager.getpid()
+    assert server_pid in [process.pid for process in psutil.process_iter()]
+
+    del shared_state
+    time.sleep(0.5)
+    assert server_pid not in [process.pid for process in psutil.process_iter()]
+
+
+def test_mutex_timeout():
+    def client1_func():
+        shared_state = SharedState()
+        with shared_state:
+            time.sleep(TIMEOUT*1.5)  # Acquire lock for longer than the (default) timeout on client2.
+
+    def client2_func():
+        shared_state = SharedState()
+        with pytest.raises(TimeoutError):
+            with shared_state:
+                pass
+
+    client1 = Process(target=client1_func)
+    client2 = Process(target=client2_func)
+    shared_state = SharedState(own=True, timeout=TIMEOUT)
+
+    client1.start()
+    time.sleep(0.5)  # Sleep to help client 1 acquire the lock 1st.
+    client2.start()
+
+    client1.join()
+    client2.join()
+
+
+def test_mutex_timeout2():
+    def client1_func():
+        shared_state = SharedState()
+        with pytest.raises(TimeoutError):
+            shared_state.from_client = 1
+
+    shared_state = SharedState(own=True, timeout=TIMEOUT)
+
+    with shared_state:
+        client1 = Process(target=client1_func)
+        client1.start()
+        client1.join()
+
+
+def test_mutex():
+    def client1_func():
+        shared_state = SharedState()
+        with shared_state:
+            shared_state.client1 = 1
+            time.sleep(TIMEOUT/4)
+
+    def client2_func():
+        shared_state = SharedState()
+        with shared_state:
+            shared_state.client2 = 2
+
+    client1 = Process(target=client1_func)
+    client2 = Process(target=client2_func)
+    shared_state = SharedState(own=True)
+
+    client1.start()
+    client2.start()
+
+    client1.join()
+    client2.join()
+
+    assert shared_state.client1 == 1
+    assert shared_state.client2 == 2
+
+
+def test_UserCache():
+    class MyCache(UserCache):
+        def load(self, key, *args, **kwargs):
+            self.data[key] = f"auto populated_{os.getpid()}_{uuid.uuid4()}"
+
+    SharedMemoryManager.register("MyCache", callable=MyCache, proxytype=MyCache.Proxy)
+
+    def client_func(item_from_parent):
+        shared_state = SharedState(own=False)
+        auto_loaded_from_parent = shared_state.my_cache["new_from_parent"]
+        assert auto_loaded_from_parent == item_from_parent, f"{auto_loaded_from_parent}, {item_from_parent}"
+
+        assert shared_state.my_cache["from_parent"] == 56789
+
+        # Test auto load from client.
+        auto_loaded_from_client = shared_state.my_cache["new_from_client"]
+        assert f"auto populated_{shared_state._manager.getpid()}" in auto_loaded_from_client
+        assert auto_loaded_from_parent != auto_loaded_from_client
+        shared_state.my_cache["from_client"] = 1234
+
+    shared_state = SharedState(own=True)
+    # Instantiate an instance of MyCache on the server and assign its proxy to SharedState.my_cache to access from
+    # any client.
+    shared_state.my_cache = shared_state._manager.MyCache()
+    shared_state.my_cache["from_parent"] = 56789
+
+    # Test auto load from parent.
+    auto_loaded_from_parent = shared_state.my_cache["new_from_parent"]
+    assert f"auto populated_{shared_state._manager.getpid()}" in auto_loaded_from_parent
+
+    client = Process(target=client_func, args=(auto_loaded_from_parent,))
+    client.start()
+    client.join()
+
+    assert f"auto populated_{shared_state._manager.getpid()}" in shared_state.my_cache["new_from_client"]
+    assert shared_state.my_cache["new_from_client"] != auto_loaded_from_parent
+    assert shared_state.my_cache["from_client"] == 1234
+
+
+def test_MutexedCache():
+    def client_func():
+        shared_state = SharedState()
+
+        with shared_state.my_cache:
+            assert shared_state.my_cache["from_parent"] == 56789
+            with shared_state.my_cache:  # Might as well test the re-entrant-ness.
+                shared_state.my_cache["from_client"] = 1234
+
+    shared_state = SharedState(own=True)
+    # Instantiate an instance of MyCache on the server and assign its proxy to SharedState.my_cache to access from
+    # any client.
+    shared_state.my_cache = shared_state._manager.MutexedCache()
+    with shared_state.my_cache:
+        shared_state.my_cache["from_parent"] = 56789
+
+    client = Process(target=client_func)
+    client.start()
+    client.join()
+
+    assert shared_state.my_cache["from_client"] == 1234
+
+
+def test_MutexedCache_timeout():
+    def client_func():
+        shared_state = SharedState()
+        with pytest.raises(TimeoutError):
+            shared_state.my_cache["from_client"] = 1234
+
+        with pytest.raises(TimeoutError):
+            with shared_state.my_cache:
+                pass
+
+    shared_state = SharedState(own=True)
+    # Instantiate an instance of MyCache on the server and assign its proxy to SharedState.my_cache to access from
+    # any client.
+    shared_state.my_cache = shared_state._manager.MutexedCache(timeout=TIMEOUT)
+    with shared_state.my_cache:
+        shared_state.my_cache["from_parent"] = 56789
+
+        client = Process(target=client_func)
+        client.start()
+        client.join()
+
+
+def test_normal_dict_update():
+    shared_state = SharedState(own=True)
+    shared_state.my_dict = {}
+    shared_state.my_dict["item_1"] = 1
+    assert shared_state.my_dict.get("item_1") is None
+
+    shared_state.my_dict = shared_state._manager.dict()
+    shared_state.my_dict["item_1"] = 1
+    assert shared_state.my_dict["item_1"] == 1
+
+
+def test_image_transfer():
+    shape = (4096, 4096)
+
+    def client_func(image_from_parent):
+        shared_state = SharedState()
+        assert shared_state.image_from_parent.data.shape == shape
+        assert np.allclose(shared_state.image_from_parent.data, image_from_parent.data)
+
+    shared_state = SharedState(own=True)
+    image = fits.PrimaryHDU(data=np.random.rand(*shape))
+    shared_state.image_from_parent = image
+
+    client = Process(target=client_func, args=(image,))
+    client.start()
+    client.join()
+
+
+def test_hdu_list_update():
+    shape = (4096, 4096)
+
+    def client_func():
+        shared_state = SharedState()
+        image_list = shared_state.nested_image_list
+        assert len(image_list) == 2, len(image_list)
+        assert image_list[0].data.shape == shape
+        assert image_list[1].data.shape == tuple([n//2 for n in shape])
+
+    SharedMemoryManager.register("HDUList", callable=fits.HDUList, proxytype=ListProxy)
+    shared_state = SharedState(own=True)
+
+    # The following will fail to update the HDUList on the server.
+    shared_state.broken_nested_image_list = fits.HDUList()
+    shared_state.broken_nested_image_list.append(fits.PrimaryHDU(data=np.random.rand(*shape)))
+    assert len(shared_state.broken_nested_image_list) == 0
+
+    # However, it'll work if you "put it back".
+    hdu_list = shared_state.broken_nested_image_list
+    hdu_list.append(fits.PrimaryHDU(data=np.random.rand(*shape)))
+    shared_state.broken_nested_image_list = hdu_list
+    assert len(shared_state.broken_nested_image_list) == 1
+
+    # The following will get updated.
+    shared_state.nested_image_list = shared_state._manager.HDUList()
+    shared_state.nested_image_list.append(fits.PrimaryHDU(data=np.random.rand(*shape)))
+    shared_state.nested_image_list.append(fits.PrimaryHDU(data=np.random.rand(*[n//2 for n in shape])))
+    assert len(shared_state.nested_image_list) == 2
+
+    # However, nesting is inevitable and thus so are failed updates, e.g., the header will not...
+    shared_state.nested_image_list[0].header["my key"] = "updated"
+    assert shared_state.nested_image_list[0].header.get("my key") is None
+
+    client = Process(target=client_func)
+    client.start()
+    client.join()
+
+
+class TestbedState(SharedState):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self._own:
+            with self:
+                self.background_cache = self._manager.dict()
+                self.mode = None
+
+    @property  # Belongs to the proxy so gets executed locally, i.e., the same process as the caller.
+    def pid(self):
+        return os.getpid()
+
+
+def test_TestbedState():
+
+    def client1_func():
+        shared_state = TestbedState()
+        with shared_state:
+            assert shared_state.mode == "initial mode", shared_state.mode
+            shared_state.mode = "client1 mode"
+            assert shared_state.mode == "client1 mode"
+
+            shared_state.background_cache["from client 1"] = 12345
+            assert shared_state.background_cache["from client 1"] == 12345
+
+            assert shared_state.pid == os.getpid()
+            assert shared_state.pid != shared_state._manager.getpid()
+
+    def client2_func():
+        shared_state = TestbedState()
+        with shared_state:
+            assert shared_state.mode == "client1 mode", shared_state.mode
+
+            assert shared_state.background_cache["from client 1"] == 12345
+
+            shared_state.background_cache["from client 2"] = 6789
+            assert shared_state.background_cache["from client 2"] == 6789
+
+            assert shared_state.pid == os.getpid()
+            assert shared_state.pid != shared_state._manager.getpid()
+
+    shared_state = TestbedState(own=True)
+    assert shared_state.mode is None
+    shared_state.mode = "initial mode"
+    assert shared_state.mode == "initial mode"
+
+    assert shared_state.pid == os.getpid()
+    assert shared_state.pid != shared_state._manager.getpid()
+
+    client1 = Process(target=client1_func)
+    client2 = Process(target=client2_func)
+
+    client1.start()
+    time.sleep(0.5)
+    client2.start()
+
+    client1.join()
+    client2.join()
+
+    assert shared_state.mode == "client1 mode"
+    assert shared_state.background_cache["from client 1"] == 12345
+    assert shared_state.background_cache["from client 2"] == 6789
+
+
+if __name__ == "__main__":
+    test_TestbedState()
+

--- a/catkit/testbed/tests/test_shared_state.py
+++ b/catkit/testbed/tests/test_shared_state.py
@@ -165,12 +165,15 @@ def test_mutex():
     assert shared_state.client2 == 2
 
 
-def test_UserCache():
-    class MyCache(UserCache):
-        def load(self, key, *args, **kwargs):
-            self.data[key] = f"auto populated_{os.getpid()}_{uuid.uuid4()}"
+class MyCache(UserCache):
+    def load(self, key, *args, **kwargs):
+        self.data[key] = f"auto populated_{os.getpid()}_{uuid.uuid4()}"
 
-    SharedMemoryManager.register("MyCache", callable=MyCache, proxytype=MyCache.Proxy)
+
+SharedMemoryManager.register("MyCache", callable=MyCache, proxytype=MyCache.Proxy)
+
+
+def test_UserCache():
 
     def client_func(item_from_parent):
         shared_state = SharedState(own=False)

--- a/catkit/testbed/tests/test_shared_state.py
+++ b/catkit/testbed/tests/test_shared_state.py
@@ -319,7 +319,7 @@ def test_hdu_list_update():
     client.join()
 
 
-class TestbedState(SharedState):
+class HicatTestbedState(SharedState):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -336,7 +336,7 @@ class TestbedState(SharedState):
 def test_TestbedState():
 
     def client1_func():
-        shared_state = TestbedState()
+        shared_state = HicatTestbedState()
         with shared_state:
             assert shared_state.mode == "initial mode", shared_state.mode
             shared_state.mode = "client1 mode"
@@ -349,7 +349,7 @@ def test_TestbedState():
             assert shared_state.pid != shared_state._manager.getpid()
 
     def client2_func():
-        shared_state = TestbedState()
+        shared_state = HicatTestbedState()
         with shared_state:
             assert shared_state.mode == "client1 mode", shared_state.mode
 
@@ -361,7 +361,7 @@ def test_TestbedState():
             assert shared_state.pid == os.getpid()
             assert shared_state.pid != shared_state._manager.getpid()
 
-    shared_state = TestbedState(own=True)
+    shared_state = HicatTestbedState(own=True)
     assert shared_state.mode is None
     shared_state.mode = "initial mode"
     assert shared_state.mode == "initial mode"

--- a/catkit/tests/test_multiprocessing.py
+++ b/catkit/tests/test_multiprocessing.py
@@ -1,0 +1,130 @@
+import os
+from threading import BrokenBarrierError
+import time
+
+from multiprocess.context import TimeoutError
+from multiprocess.managers import State
+import pytest
+
+from catkit.multiprocessing import Process, SharedMemoryManager
+
+TIMEOUT = 10  # Use a shorter timeout for testing.
+
+
+def test_child_exception():
+    def client_func():
+        raise RuntimeError("123456789")
+
+    with SharedMemoryManager() as manager:
+        client = Process(target=client_func)
+        client.start()
+        with pytest.raises(RuntimeError, match="123456789"):
+            client.join()
+
+
+def test_pid():
+    def client_func(pid):
+        manager = SharedMemoryManager()
+        manager.connect()
+        server_pid = manager.getpid()
+
+        client_pid = os.getpid()
+        assert server_pid != client_pid, f"Server ({server_pid}) shouldn't be running on client ({client_pid})"
+        assert server_pid == pid, f"Server ({server_pid}) connected to from client ({client_pid}) should be same as that started by manager ({pid})"
+
+    with SharedMemoryManager() as manager:
+        parent_pid = os.getpid()
+        server_pid = manager.getpid()
+
+        assert server_pid != parent_pid
+
+        n_clients = 2
+        clients = [Process(target=client_func, args=(server_pid,)) for x in range(n_clients)]
+
+        for client in clients:
+            client.start()
+
+        for client in clients:
+            client.join()
+
+
+def test_no_persistent_server():
+    manager = SharedMemoryManager()
+    with pytest.raises(ConnectionRefusedError):
+        manager.connect()
+
+
+def test_locks():
+    def client_func2():
+        manager = SharedMemoryManager()
+        manager.connect()
+        with pytest.raises(TimeoutError):
+            with manager.get_lock("test_lock"):  # This will timeout as the parent process has already acquired this.
+                pass
+
+    client = Process(target=client_func2)
+
+    with SharedMemoryManager() as manager:
+        assert manager._state.value == State.STARTED  # Oddly manager._state is State.Started doesn't work.
+        with manager.get_lock("test_lock", timeout=TIMEOUT) as is_locked:
+            assert is_locked
+            client.start()
+            client.join()
+
+
+def client_barrier(sleep, parties, l, name_mangle=False):
+    manager = SharedMemoryManager()
+    manager.connect()
+    name = f"test_barrier_{sleep}" if name_mangle else "test_barrier"
+    barrier = manager.get_barrier(name, parties)
+    t0 = time.time()
+    time.sleep(sleep)
+    barrier.wait(timeout=TIMEOUT)  # NOTE: The barrier release order is not guaranteed.
+    l.append(int(time.time() - t0))
+
+
+def test_single_barrier():
+    with SharedMemoryManager() as manager:
+        l = manager.list()
+
+        clients = [Process(target=client_barrier, args=(6, 3, l)),
+                   Process(target=client_barrier, args=(0, 3, l)),
+                   Process(target=client_barrier, args=(0, 3, l))]
+
+        for client in clients:
+            client.start()
+
+        for client in clients:
+            client.join()
+
+        # We Expect to see that the timer wrapping the sleep and the barrier for each client to be that of the longest.
+        assert l._getvalue() == [6, 6, 6], l._getvalue()
+
+
+def test_multiple_barriers():
+    with SharedMemoryManager() as manager:
+        l = manager.list()
+
+        clients = [Process(target=client_barrier, args=(6, 1, l, True)),
+                   Process(target=client_barrier, args=(0, 1, l, True)),
+                   Process(target=client_barrier, args=(0, 1, l, True))]
+
+        for client in clients:
+            client.start()
+
+        for client in clients:
+            client.join()
+
+        # We Expect to see that the timer wrapping the sleep and the barrier for each client to be that of their sleep.
+        assert l._getvalue() == [0, 0, 6], l._getvalue()
+
+
+def test_broken_barrier():
+    with SharedMemoryManager() as manager:
+        l = manager.list()
+
+        # More parties than process will cause barrier.wait() to timeout.
+        client = Process(target=client_barrier, args=(6, 3, l))
+        client.start()
+        with pytest.raises(BrokenBarrierError):
+            client.join()

--- a/catkit/tests/test_multiprocessing.py
+++ b/catkit/tests/test_multiprocessing.py
@@ -4,6 +4,7 @@ import time
 
 from multiprocess.context import TimeoutError
 from multiprocess.managers import State
+import numpy as np
 import pytest
 
 from catkit.multiprocessing import Process, SharedMemoryManager
@@ -80,7 +81,7 @@ def client_barrier(sleep, parties, l, name_mangle=False):
     t0 = time.time()
     time.sleep(sleep)
     barrier.wait(timeout=TIMEOUT)  # NOTE: The barrier release order is not guaranteed.
-    l.append(int(time.time() - t0))
+    l.append(np.rint(time.time() - t0))
 
 
 def test_single_barrier():

--- a/catkit/util.py
+++ b/catkit/util.py
@@ -212,6 +212,11 @@ def soft_kill(process):
     wait until the process closes.  Uses a console ctrl event for windows, and signal.SIGINT for linux/mac.
     :param process: A multiprocessing.Process object.
     """
+
+    # The process may not have even started...
+    if not process or process.pid is None or not process.is_alive():
+        return
+
     log = logging.getLogger()
     if os.name == "nt":
         import win32api

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - flake8
   - h5py
   - matplotlib
+  - conda-forge::multiprocess
   - pip
   - psutil
   - pyserial


### PR DESCRIPTION
- [x] Tested on hardware with  https://github.com/spacetelescope/hicat-package/pull/582 ``2021-05-18T12-41-27_broadband_stroke_minimization``

A future PR may add a comparison proxy to remove the need of calling ``_getvalue()`` for some comparison scenarios.

Signed-off-by: James Noss <jnoss@stsci.edu>