### PR TITLE
CATKIT-95 Raise exception upon non-zero exitcode of child process

### DIFF
--- a/catkit/testbed/experiment.py
+++ b/catkit/testbed/experiment.py
@@ -155,6 +155,10 @@ class Experiment(ABC):
             # must return SafetyException type specifically to signal queue to stop in typical calling scripts
             raise safety_exception
 
+        experiment_process.join()
+        if experiment_process.exitcode:
+            raise Exception(f"Child process ('{self.name}' with pid: '{experiment_process.pid}') exited with non-zero exitcode: '{experiment_process.exitcode}'")
+
     def run_experiment(self):
         """
         Wrapper for experiment to catch the softkill function's KeyboardInterrupt signal more gracefully.


### PR DESCRIPTION
Discovered when testing https://github.com/spacetelescope/catkit/pull/234 and https://github.com/spacetelescope/hicat-package/pull/582

This exposes an existing bug (or more) in https://github.com/spacetelescope/hicat-package/blob/develop/hicat/wfc_algorithms/tests/test_pairwise.py

Fail: https://github.com/spacetelescope/catkit/pull/235/checks?check_run_id=2531333411#step:6:871
```python
Traceback (most recent call last):
  File "/home/runner/work/catkit/catkit/catkit/testbed/experiment.py", line 192, in run_experiment
    self.experiment_return = self.experiment()
  File "/home/runner/work/catkit/hicat-package/hicat/experiments/PairwiseSensing.py", line 127, in experiment
    **exposure_kwargs)
  File "/home/runner/work/catkit/hicat-package/hicat/wfc_algorithms/wfsc_utils.py", line 248, in take_exposure_hicat
    **pipeline_kwargs)
  File "/home/runner/work/catkit/hicat-package/hicat/hardware/testbed.py", line 1236, in expose_and_calibrate
    **(pipeline_kwargs if pipeline_kwargs else dict()))
  File "/home/runner/work/catkit/hicat-package/hicat/data_pipeline_lite.py", line 345, in data_pipeline
    err_hdu=err_hdu)
  File "/home/runner/work/catkit/hicat-package/hicat/data_pipeline_lite.py", line 390, in _write_data
    calibrated_hdu.writeto(calibrated_filename, overwrite=False)
  File "/usr/share/miniconda/envs/ci-env/lib/python3.7/site-packages/astropy/utils/decorators.py", line 535, in wrapper
    return function(*args, **kwargs)
  File "/usr/share/miniconda/envs/ci-env/lib/python3.7/site-packages/astropy/io/fits/hdu/base.py", line 372, in writeto
    checksum=checksum)
  File "/usr/share/miniconda/envs/ci-env/lib/python3.7/site-packages/astropy/utils/decorators.py", line 535, in wrapper
    return function(*args, **kwargs)
  File "/usr/share/miniconda/envs/ci-env/lib/python3.7/site-packages/astropy/io/fits/hdu/hdulist.py", line 933, in writeto
    fileobj = _File(fileobj, mode=mode, overwrite=overwrite)
  File "/usr/share/miniconda/envs/ci-env/lib/python3.7/site-packages/astropy/utils/decorators.py", line 535, in wrapper
    return function(*args, **kwargs)
  File "/usr/share/miniconda/envs/ci-env/lib/python3.7/site-packages/astropy/io/fits/file.py", line 175, in __init__
    self._open_filename(fileobj, mode, overwrite)
  File "/usr/share/miniconda/envs/ci-env/lib/python3.7/site-packages/astropy/io/fits/file.py", line 553, in _open_filename
    self._overwrite_existing(overwrite, None, True)
  File "/usr/share/miniconda/envs/ci-env/lib/python3.7/site-packages/astropy/io/fits/file.py", line 443, in _overwrite_existing
    raise OSError(f"File {self.name!r} already exists.")
OSError: File '/tmp/pytest-of-runner/pytest-0/test_run_pairwise_no_exception0/simulations/2021-05-07T22-03-32_pairwise_sim=True_ncyc=13_angle=0_phase=45_amp=6_rcondHinv=0.1/before/coron_640/coron_image.fits_cal.fits' already exists.
```

Signed-off-by: James Noss <jnoss@stsci.edu>