### PR TITLE
CATKIT-96: Reduce file IO overhead for sending commands to BMC

### DIFF
--- a/catkit/hardware/boston/DmCommand.py
+++ b/catkit/hardware/boston/DmCommand.py
@@ -182,6 +182,11 @@ def load_dm_command(path, dm_num=1, flat_map=False, bias=False, as_volts=False):
 
 
 def get_flat_map_volts(dm_num):
+    """
+    Get the flat map for a given dm. The flat map is in volts for each actuator.
+    :param dm_num: Which DM to lead the command for.
+    :return: flat map for the selected DM. This function caches the map to avoid multiple disk access.
+    """
     calibration_data_package = CONFIG_INI.get("optics_lab", "calibration_data_package")
     calibration_data_path = os.path.join(catkit.util.find_package_location(calibration_data_package),
                                          "hardware",
@@ -189,15 +194,21 @@ def get_flat_map_volts(dm_num):
 
     global flat_map_dm1, flat_map_dm2
 
-    if flat_map_dm1 is None:
-        fname = CONFIG_INI.get("boston_kilo952", "flat_map_dm1")
-        flat_map_dm1 = fits.getdata(os.path.join(calibration_data_path, fname))
+    if dm_num == 1:
+        if flat_map_dm1 is None:
+            fname = CONFIG_INI.get("boston_kilo952", "flat_map_dm1")
+            flat_map_dm1 = fits.getdata(os.path.join(calibration_data_path, fname))
 
-    if flat_map_dm2 is None:
-        fname = CONFIG_INI.get("boston_kilo952", "flat_map_dm2")
-        flat_map_dm2 = fits.getdata(os.path.join(calibration_data_path, fname))
+        return flat_map_dm1
 
-    return flat_map_dm1 if dm_num == 1 else flat_map_dm2
+    if dm_num == 2:
+        if flat_map_dm2 is None:
+            fname = CONFIG_INI.get("boston_kilo952", "flat_map_dm2")
+            flat_map_dm2 = fits.getdata(os.path.join(calibration_data_path, fname))
+
+        return flat_map_dm2
+
+    raise ValueError('dm_num should be either 1 or 2.')
 
 
 def get_m_per_volt_map(dm_num):
@@ -212,14 +223,22 @@ def get_m_per_volt_map(dm_num):
                                          "boston")
 
     global m_per_volt_map1, m_per_volt_map2
-    if m_per_volt_map1 is None:
-        m_per_volt_map1 = fits.getdata(os.path.join(calibration_data_path,
-                                               CONFIG_INI.get("boston_kilo952", "gain_map_dm1")))
-    if m_per_volt_map2 is None:
-        m_per_volt_map2 = fits.getdata(os.path.join(calibration_data_path,
-                                               CONFIG_INI.get("boston_kilo952", "gain_map_dm2")))
 
-    return m_per_volt_map1 if dm_num == 1 else m_per_volt_map2
+    if dm_num == 1:
+        if m_per_volt_map1 is None:
+            fname = CONFIG_INI.get("boston_kilo952", "gain_map_dm1")
+            m_per_volt_map1 = fits.getdata(os.path.join(calibration_data_path, fname))
+
+        return m_per_volt_map1
+
+    if dm_num == 2:
+        if m_per_volt_map2 is None:
+            fname = CONFIG_INI.get("boston_kilo952", "gain_map_dm2")
+            m_per_volt_map2 = fits.getdata(os.path.join(calibration_data_path, fname))
+
+        return m_per_volt_map2
+
+    raise ValueError('dm_num should be either 1 or 2.')
 
 
 def convert_volts_to_m(data, dm_num, meter_to_volt_map=None):

--- a/catkit/hardware/boston/DmCommand.py
+++ b/catkit/hardware/boston/DmCommand.py
@@ -261,14 +261,11 @@ def convert_m_to_volts(data, dm_num, meter_to_volt_map=None):
 
 
 def convert_dm_command_to_image(dm_command):
-    # Flatten the mask using index952
-    mask = catkit.util.get_dm_mask()
-    index952 = np.flatnonzero(mask)
+    mask = catkit.util.get_dm_mask().astype('bool')
+    number_of_actuators = np.count_nonzero(mask)
 
-    number_of_actuators_per_dimension = CONFIG_INI.getint('boston_kilo952', 'dm_length_actuators')
-    number_of_actuators = CONFIG_INI.getint("boston_kilo952", "number_of_actuators")
-    image = np.zeros((number_of_actuators_per_dimension, number_of_actuators_per_dimension))
-    image[np.unravel_index(index952, image.shape)] = dm_command[:number_of_actuators]
+    image = np.zeros(mask.shape)
+    image[mask] = dm_command[:number_of_actuators]
 
     return image
 

--- a/catkit/util.py
+++ b/catkit/util.py
@@ -25,14 +25,19 @@ def find_package_location(package='catkit'):
     return importlib.util.find_spec(package).submodule_search_locations[0]
 
 
-def find_repo_location(package='cakit'):
+def find_repo_location(package='catkit'):
     return os.path.abspath(os.path.join(find_package_location(package), os.pardir))
 
 
 def get_dm_mask():
-    mask_path = os.path.join(find_package_location("catkit"), "hardware", "boston", "kiloCdm_2Dmask.fits")
-    mask = fits.open(mask_path)[0].data
-    return mask
+    if get_dm_mask.mask is None:
+        mask_path = os.path.join(find_package_location("catkit"), "hardware", "boston", "kiloCdm_2Dmask.fits")
+        mask = fits.getdata(mask_path)
+
+    return get_dm_mask.mask
+
+
+get_dm_mask.mask = None
 
 
 # Does numpy gotchu?

--- a/catkit/util.py
+++ b/catkit/util.py
@@ -30,14 +30,11 @@ def find_repo_location(package='catkit'):
 
 
 def get_dm_mask():
-    if get_dm_mask.mask is None:
+    if not hasattr(get_dm_mask, 'mask'):
         mask_path = os.path.join(find_package_location("catkit"), "hardware", "boston", "kiloCdm_2Dmask.fits")
         get_dm_mask.mask = fits.getdata(mask_path)
 
     return get_dm_mask.mask
-
-
-get_dm_mask.mask = None
 
 
 # Does numpy gotchu?

--- a/catkit/util.py
+++ b/catkit/util.py
@@ -32,7 +32,7 @@ def find_repo_location(package='catkit'):
 def get_dm_mask():
     if get_dm_mask.mask is None:
         mask_path = os.path.join(find_package_location("catkit"), "hardware", "boston", "kiloCdm_2Dmask.fits")
-        mask = fits.getdata(mask_path)
+        get_dm_mask.mask = fits.getdata(mask_path)
 
     return get_dm_mask.mask
 


### PR DESCRIPTION
This PR caches the flat maps and dm mask which were read every time a DM command was sent to the Boston. This reduces the timing:

Before this PR:
My machine on simulator: 6.4-7.0ms.
Hicat2 on hardware: 4.7-4.8 ms.

After this PR:
My machine on simulator: 1.0ms.
Hicat2 on hardware: 0.71-0.81 ms.

- [X] Tested strokemin and performance on simulator.
- [x] Tested performance on hardware.
- [x] Full strokemin on hardware? (is this necessary?)