### PR TITLE
Adding channels to the BMC DM.

### DIFF
--- a/catkit/hardware/boston/BostonDmController.py
+++ b/catkit/hardware/boston/BostonDmController.py
@@ -114,7 +114,7 @@ class BostonDmController(DeformableMirrorController):
                             as_volts=False,
                             sin_specification=None,
                             output_path=None,
-                            channel=None
+                            channel=None,
                             do_logging=True):
         """ Combines both commands and sends to the controller to produce a shape on each DM.
         :param dm<1|2>_shape: catkit.hardware.boston.DmCommand.DmCommand or numpy array of the following shapes: 34x34, 1x952,


### PR DESCRIPTION
This adds channels to the BMC DM.

Channels act as individual contributions to the DM shape. One channel can be updated at a time, without disturbing other contributions to the DM. This allows multiple loops to apply corrections to the DM, without knowing about the state of other loops. A channel requires a name (as string). Using `None` as the channel (default), rewrites the whole DM shape and doesn't take into account any set channel contributions. This way, everything is backwards compatible.

This PR also adds a lock / mutex to the `apply_shape_to_both()` function. This is necessary for multiple loops running in the same process and sending commands to the DM at potentially the same time. Access to the internal memory for channels is serialized.

I also made logging optional (opt-out; default is still to emit log messages). Having a loop send commands to the BMC at >100Hz makes the log files quite unreadable without.