### PR TITLE
HICAT-994 Device servers using Python shared memory managers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
     name: flake8 (syntax only) on Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         python-version: [3.7]
     env:

--- a/catkit/conftest.py
+++ b/catkit/conftest.py
@@ -1,11 +1,19 @@
 import gc
+import os
 
 import pytest
 
+from catkit.emulators.npoint_tiptilt import SimNPointLC400
 from catkit.testbed import devices
+from catkit.testbed.caching import DeviceCacheEnum, SharedSingletonDeviceCache
 import catkit.util
+from catkit.multiprocessing import EXCEPTION_SERVER_ADDRESS, SharedMemoryManager
 
 catkit.util.simulation = True
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "dont_own_exception_handler: Neither start nor shutdown the exception handler server.")
 
 
 @pytest.fixture(scope="function", autouse=False)
@@ -18,3 +26,12 @@ def derestricted_device_cache():
         devices["npoint_a"]
     # Teardown.
     gc.collect()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def exception_handler(request):
+    if "dont_own_exception_handler" not in request.keywords:
+        with SharedMemoryManager(address=EXCEPTION_SERVER_ADDRESS):
+            yield
+    else:
+        yield

--- a/catkit/conftest.py
+++ b/catkit/conftest.py
@@ -1,11 +1,9 @@
 import gc
-import os
 
 import pytest
 
-from catkit.emulators.npoint_tiptilt import SimNPointLC400
 from catkit.testbed import devices
-from catkit.testbed.caching import DeviceCacheEnum, SharedSingletonDeviceCache
+from catkit.testbed.caching import DeviceCacheEnum
 import catkit.util
 from catkit.multiprocessing import EXCEPTION_SERVER_ADDRESS, SharedMemoryManager
 
@@ -35,3 +33,9 @@ def exception_handler(request):
             yield
     else:
         yield
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clear_lru_cache():
+    DeviceCacheEnum.get_device.cache_clear()
+    DeviceCacheEnum._missing_.cache_clear()

--- a/catkit/datalogging/data_log_io.py
+++ b/catkit/datalogging/data_log_io.py
@@ -240,6 +240,8 @@ class DataLogWriter(object):
         if index_fname is None:
             index_fname = _INDEX_FNAME
 
+        os.makedirs(self.log_dir, exist_ok=False)
+
         self.index_path = os.path.join(log_dir, index_fname)
 
         if os.path.exists(self.index_path):

--- a/catkit/datalogging/data_log_io.py
+++ b/catkit/datalogging/data_log_io.py
@@ -215,6 +215,7 @@ class SerializableEvent(Event):
         self._serialized_length = None
         self._log_dir = None
 
+
 class DataLogWriter(object):
     '''A writer to write events to a binary log file.
 
@@ -240,7 +241,7 @@ class DataLogWriter(object):
         if index_fname is None:
             index_fname = _INDEX_FNAME
 
-        os.makedirs(self.log_dir, exist_ok=False)
+        os.makedirs(self.log_dir, exist_ok=True)
 
         self.index_path = os.path.join(log_dir, index_fname)
 
@@ -254,6 +255,14 @@ class DataLogWriter(object):
 
         self._n = 0
         self._closed = False
+
+    def __enter__(self):
+        # TODO: Should/can this ADD itself to catkit.datalogging?
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # TODO: Should/can this REMOVE itself to catkit.datalogging?
+        return self.close()
 
     def log(self, wall_time, tag, value, value_type):
         '''Add an event to the log file.
@@ -333,6 +342,7 @@ class DataLogWriter(object):
 
         self._closed = True
 
+
 class DataLogReader(object):
     '''A reader for data log files produced by `DataLogWriter`.
 
@@ -360,6 +370,12 @@ class DataLogReader(object):
         self._last_modified = 0
 
         self.reload()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return self.close()
 
     def reload(self, force=False):
         '''Reload the data log from disk.

--- a/catkit/datalogging/tests/test_datalogging.py
+++ b/catkit/datalogging/tests/test_datalogging.py
@@ -6,86 +6,68 @@ import shutil
 
 import catkit.datalogging
 
-def test_data_log_interface():
+
+def test_data_log_interface(tmpdir):
     logger = catkit.datalogging.get_logger(__name__)
 
     # Make sure this doesn't crash, even though nothing should be written out.
     logger.log_scalar('tag', 5)
 
-    log_dir = './data_log_test'
-    if os.path.exists(log_dir):
-        shutil.rmtree(log_dir)
-    os.makedirs(log_dir)
+    with catkit.datalogging.DataLogWriter(tmpdir):
+        logger.log_scalar('tag2', 10)
 
-    writer = catkit.datalogging.DataLogWriter(log_dir)
 
-    logger.log_scalar('tag2', 10)
-
-    # Cleanup
-    writer.close()
-    shutil.rmtree(log_dir)
-
-def test_data_log_retrieval():
+def test_data_log_retrieval(tmpdir):
     logger = catkit.datalogging.get_logger(__name__)
 
-    log_dir = './data_log_test'
-    if os.path.exists(log_dir):
-        shutil.rmtree(log_dir)
-    os.makedirs(log_dir)
+    with catkit.datalogging.DataLogWriter(tmpdir) as writer:
+        catkit.datalogging.DataLogger.add_writer(writer)
 
-    writer = catkit.datalogging.DataLogWriter(log_dir)
-    catkit.datalogging.DataLogger.add_writer(writer)
+        scalar = float(np.random.randn(1))
+        tensor = np.random.randn(100, 250)
+        curve_x = np.random.randn(30)
+        curve_y = np.random.randn(30)
 
-    scalar = float(np.random.randn(1))
-    tensor = np.random.randn(100, 250)
-    curve_x = np.random.randn(30)
-    curve_y = np.random.randn(30)
+        plt.plot(curve_x, curve_y)
 
-    plt.plot(curve_x, curve_y)
+        hdu = fits.PrimaryHDU(tensor)
+        fits_fname = os.path.join(tmpdir, 'tensor.fits')
+        hdu.writeto(fits_fname)
 
-    hdu = fits.PrimaryHDU(tensor)
-    fits_fname = os.path.join(log_dir, 'tensor.fits')
-    hdu.writeto(fits_fname)
+        logger.log_scalar('a', scalar)
+        logger.log_scalar('a', scalar * 2)
+        logger.log_scalar('a', scalar * -0.5)
 
-    logger.log_scalar('a', scalar)
-    logger.log_scalar('a', scalar * 2)
-    logger.log_scalar('a', scalar * -0.5)
+        logger.log_tensor('b', tensor)
 
-    logger.log_tensor('b', tensor)
+        logger.log_curve('c', curve_x, curve_y)
 
-    logger.log_curve('c', curve_x, curve_y)
+        logger.log_figure('d')
 
-    logger.log_figure('d')
+        logger.log_fits_file('e', fits_fname)
 
-    logger.log_fits_file('e', fits_fname)
+        # Unregister writer
+        catkit.datalogging.DataLogger.remove_writer(writer)
 
-    # Unregister writer
-    catkit.datalogging.DataLogger.remove_writer(writer)
-    writer.close()
+    with catkit.datalogging.DataLogReader(tmpdir) as reader:
 
-    reader = catkit.datalogging.DataLogReader(log_dir)
+        wall_time, scalars = reader.get('a')
+        assert np.allclose(scalars[0], scalar)
+        assert len(scalars) == 3
 
-    wall_time, scalars = reader.get('a')
-    assert np.allclose(scalars[0], scalar)
-    assert len(scalars) == 3
+        wall_time, scalars = reader.get('a', slice(1,None))
+        assert len(scalars) == 2
+        assert len(wall_time) == 2
 
-    wall_time, scalars = reader.get('a', slice(1,None))
-    assert len(scalars) == 2
-    assert len(wall_time) == 2
+        wall_time, tensors = reader.get('b')
+        assert np.allclose(tensors[0], tensor)
 
-    wall_time, tensors = reader.get('b')
-    assert np.allclose(tensors[0], tensor)
+        wall_time, curve = reader.get('c')
+        assert np.allclose(curve[0]['x'], curve_x)
+        assert np.allclose(curve[0]['y'], curve_y)
 
-    wall_time, curve = reader.get('c')
-    assert np.allclose(curve[0]['x'], curve_x)
-    assert np.allclose(curve[0]['y'], curve_y)
+        wall_time, figs = reader.get('d')
+        assert figs[0].ndim == 3
 
-    wall_time, figs = reader.get('d')
-    assert figs[0].ndim == 3
-
-    wall_time, fits_files = reader.get('e')
-    assert np.allclose(fits_files[0][0].data, tensor)
-
-    # Cleanup
-    reader.close()
-    shutil.rmtree(log_dir)
+        wall_time, fits_files = reader.get('e')
+        assert np.allclose(fits_files[0][0].data, tensor)

--- a/catkit/emulators/ZwoCamera.py
+++ b/catkit/emulators/ZwoCamera.py
@@ -27,7 +27,7 @@ class ZwoEmulator(ZwoASI):
         return camera_mappings
 
     def __init__(self, config_id):
-        self.log = logging.getLogger(__name__)
+        self.log = logging.getLogger()
 
         self.config_id = config_id
         self.image_type = None

--- a/catkit/emulators/boston_dm.py
+++ b/catkit/emulators/boston_dm.py
@@ -9,9 +9,10 @@ import catkit.util
 import catkit.hardware.boston.DmCommand
 from catkit.hardware.boston.BostonDmController import BostonDmController
 from catkit.interfaces.Instrument import SimInstrument
+from catkit.multiprocessing import MutexedNamespace
 
 
-class PoppyBostonDM(poppy.dms.ContinuousDeformableMirror):
+class PoppyBostonDM(MutexedNamespace, poppy.dms.ContinuousDeformableMirror):
     """
     Wraps `poppy.dms.ContinuousDeformableMirror` so as to encapsulate the additional DM
     attributes required to describe a typical Boston Micromachines DM.
@@ -52,7 +53,7 @@ class PoppyBmcEmulator:
     NO_ERR = 0
 
     def __init__(self, num_actuators, command_length, dac_bit_width, dm1, dm2=None):
-        self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__qualname__}")
+        self.log = logging.getLogger()
         self._num_actuators = num_actuators
         self._command_length = command_length
         self._dac_bit_width = dac_bit_width
@@ -60,9 +61,9 @@ class PoppyBmcEmulator:
         self.dm2 = dm2
 
         # As the class name suggests, the design only works with ``poppy.dms.ContinuousDeformableMirror``.
-        assert isinstance(dm1, PoppyBostonDM)
-        if dm2 is not None:
-            assert isinstance(dm2, PoppyBostonDM)
+        # assert isinstance(dm1, (PoppyBostonDM, PoppyBostonDM.Proxy)), type(dm1)
+        # if dm2 is not None:
+        #     assert isinstance(dm2, (PoppyBostonDM, PoppyBostonDM.Proxy))
 
     def BmcDm(self):
         return self

--- a/catkit/emulators/boston_dm.py
+++ b/catkit/emulators/boston_dm.py
@@ -1,8 +1,8 @@
 import copy
 import logging
 
+from multiprocess.managers import BaseProxy
 import numpy as np
-
 import poppy.dms
 
 import catkit.util
@@ -61,9 +61,9 @@ class PoppyBmcEmulator:
         self.dm2 = dm2
 
         # As the class name suggests, the design only works with ``poppy.dms.ContinuousDeformableMirror``.
-        # assert isinstance(dm1, (PoppyBostonDM, PoppyBostonDM.Proxy)), type(dm1)
-        # if dm2 is not None:
-        #     assert isinstance(dm2, (PoppyBostonDM, PoppyBostonDM.Proxy))
+        assert isinstance(dm1, (PoppyBostonDM, BaseProxy)), type(dm1)
+        if dm2 is not None:
+            assert isinstance(dm2, (PoppyBostonDM, BaseProxy)), type(dm2)
 
     def BmcDm(self):
         return self

--- a/catkit/emulators/iris_ao_controller.py
+++ b/catkit/emulators/iris_ao_controller.py
@@ -9,10 +9,11 @@ import catkit.hardware.iris_ao.segmented_dm_command as segmented_dm_command
 import catkit.hardware.iris_ao.util
 from catkit.interfaces.Instrument import SimInstrument
 import catkit.util
+from catkit.multiprocessing import MutexedNamespace
 from packaging.version import Version
 
 
-class PoppyIrisAODM(poppy.dms.HexSegmentedDeformableMirror):
+class PoppyIrisAODM(MutexedNamespace, poppy.dms.HexSegmentedDeformableMirror):
 
     @property
     def number_of_segments(self):
@@ -94,7 +95,7 @@ class PoppyIrisAOEmulator:
 
         self.driver_serial = driver_serial
 
-        assert isinstance(dm, PoppyIrisAODM)
+        # assert isinstance(dm, PoppyIrisAODM)
         self.dm = dm  # An instance of PoppyIrisAODM.
 
     def Popen(self,

--- a/catkit/emulators/iris_ao_controller.py
+++ b/catkit/emulators/iris_ao_controller.py
@@ -1,6 +1,7 @@
 import os
 
 import astropy.units as u
+from multiprocess.managers import BaseProxy
 import numpy as np
 import poppy
 
@@ -95,7 +96,7 @@ class PoppyIrisAOEmulator:
 
         self.driver_serial = driver_serial
 
-        # assert isinstance(dm, PoppyIrisAODM)
+        assert isinstance(dm, (PoppyIrisAODM, BaseProxy)), type(dm)
         self.dm = dm  # An instance of PoppyIrisAODM.
 
     def Popen(self,

--- a/catkit/emulators/newport/NewportMotorController.py
+++ b/catkit/emulators/newport/NewportMotorController.py
@@ -6,7 +6,7 @@ class NewportMotorControllerEmulator:
 
     def __init__(self):
         self.current_position = {}
-        self.log = logging.getLogger(__name__)
+        self.log = logging.getLogger()
 
     def XPS(self, *args, **kwargs):
         return self

--- a/catkit/emulators/npoint_tiptilt.py
+++ b/catkit/emulators/npoint_tiptilt.py
@@ -30,7 +30,7 @@ class PyvisaNpointEmulator:
         can read values, this is where we'll initialize some value stores that
         will get sent in emulated messages. """
 
-        self.log = logging.getLogger(f"{self.__module__}.{self.__class__.__qualname__}")
+        self.log = logging.getLogger()
         self.initialize()
 
     def initialize(self):

--- a/catkit/emulators/tests/test_emulated_boston_dm.py
+++ b/catkit/emulators/tests/test_emulated_boston_dm.py
@@ -77,7 +77,7 @@ class TestPoppyBostonDMController:
         with self.instantiate_dm_controller() as dm:
             dm.apply_shape_to_both(flat_dm1, flat_dm2)
 
-        assert dm.instrument is None
+        assert not dm.is_open()
 
     def test_subsequent_with(self):
         flat_dm1 = DmCommand(np.zeros(self.number_of_actuators), 1)
@@ -85,13 +85,13 @@ class TestPoppyBostonDMController:
         with self.instantiate_dm_controller() as dm:
             dm.apply_shape_to_both(flat_dm1, flat_dm2)
 
-        assert dm.instrument is None
+        assert not dm.is_open()
 
         assert dm
         with dm:
             dm.apply_shape_to_both(flat_dm1, flat_dm2)
 
-        assert dm.instrument is None
+        assert not dm.is_open()
 
     def test_access_after_with(self):
         flat_dm1 = DmCommand(np.zeros(self.number_of_actuators), 1)
@@ -117,7 +117,7 @@ class TestPoppyBostonDMController:
 
         dm.apply_shape_to_both(flat_dm1, flat_dm2)
         dm._Instrument__close()
-        assert dm.instrument is None
+        assert not dm.is_open()
         assert not dm._Instrument__keep_alive
 
     def test_del(self):

--- a/catkit/hardware/SnmpUps.py
+++ b/catkit/hardware/SnmpUps.py
@@ -8,7 +8,7 @@ from catkit.interfaces.BackupPower import BackupPower
 
 class SnmpUps(BackupPower):
 
-    log = logging.getLogger(__name__)
+    log = logging.getLogger()
 
     def __init__(self, config_id, ip, snmp_oid, pass_status, port=161, community="public"):
         self.config_id = config_id

--- a/catkit/hardware/WebPowerSwitch.py
+++ b/catkit/hardware/WebPowerSwitch.py
@@ -19,7 +19,7 @@ class WebPowerSwitch(RemotePowerSwitch):
     instrument_lib = requests
 
     def initialize(self, user=None, password=None, ip=None, outlet_list={}):
-        self.log = logging.getLogger(__name__)
+        self.log = logging.getLogger()
 
         # Given the specificity of the script numbering I'm not sure that it really makes sense
         # to pass in these values, but hey.

--- a/catkit/hardware/boston/BostonDmController.py
+++ b/catkit/hardware/boston/BostonDmController.py
@@ -5,7 +5,8 @@ import threading
 import numpy as np
 
 from catkit.interfaces.DeformableMirrorController import DeformableMirrorController
-from catkit.hardware.boston.DmCommand import DmCommand, convert_dm_image_to_command
+from catkit.hardware.boston.DmCommand import DmCommand
+from catkit.multiprocessing import SharedMemoryManager
 
 
 # BMC is Boston's library and it only works on windows.
@@ -286,3 +287,17 @@ class BostonDmController(DeformableMirrorController):
             else:
                 self.dm2_command = dm_command
                 self.dm2_command_object = dm_shape
+
+    class PerformantProxy(DeformableMirrorController.PerformantProxy):
+        @property
+        def dm1_command_object(self):
+            return self._callmethod("__getattribute__", args=("dm1_command_object",))
+
+        @property
+        def dm2_command_object(self):
+            return self._callmethod("__getattribute__", args=("dm2_command_object",))
+
+
+SharedMemoryManager.register("BostonDMPerformantProxy",
+                             proxytype=BostonDmController.PerformantProxy,
+                             create_method=False)

--- a/catkit/hardware/boston/BostonDmController.py
+++ b/catkit/hardware/boston/BostonDmController.py
@@ -5,7 +5,7 @@ import threading
 import numpy as np
 
 from catkit.interfaces.DeformableMirrorController import DeformableMirrorController
-from catkit.hardware.boston.DmCommand import DmCommand
+from catkit.hardware.boston.DmCommand import DmCommand, convert_dm_image_to_command
 from catkit.multiprocessing import SharedMemoryManager
 
 

--- a/catkit/hardware/newport/NewportPicomotorController.py
+++ b/catkit/hardware/newport/NewportPicomotorController.py
@@ -15,7 +15,7 @@ import functools
 
 from http.client import IncompleteRead
 import numpy as np
-from photutils import centroid_1dg, centroid_2dg
+from photutils.centroids import centroid_1dg, centroid_2dg
 from requests.exceptions import HTTPError
 import urllib
 from urllib.parse import urlencode

--- a/catkit/hardware/sbig/SbigCamera.py
+++ b/catkit/hardware/sbig/SbigCamera.py
@@ -29,7 +29,7 @@ class SbigCamera(Camera):
     NO_IMAGE_AVAILABLE = 0
     IMAGE_AVAILABLE = 1
 
-    log = logging.getLogger(__name__)
+    log = logging.getLogger()
 
     def initialize(self, *args, **kwargs):
         """Loads the SBIG config information and verifies that the camera is idle.

--- a/catkit/interfaces/Camera.py
+++ b/catkit/interfaces/Camera.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 
-from catkit.interfaces.Instrument import Instrument
+from catkit.interfaces.Instrument import Instrument, InstrumentBaseProxy
+from catkit.multiprocessing import SharedMemoryManager
 """Abstract base class for all cameras. Implementations of this class also become context managers."""
 
 
@@ -13,3 +14,19 @@ class Camera(Instrument, ABC):
     @abstractmethod
     def stream_exposures(self, exposure_time, num_exposures, *args, **kwargs):
         """ Take a stream of exposures and yield individual images (ie. a generator)."""
+
+    class Proxy(Instrument.Proxy):
+        _method_to_typeid_ = Instrument.Proxy._method_to_typeid_.copy()
+        _method_to_typeid_["__enter__"] = "CameraProxy"
+        _method_to_typeid_["stream_exposures"] = "Iterator"
+
+        # NOTE: The following shouldn't be necessary as it should be inherited from its base (WIP).
+        # See comments regarding inheritance in catkit.multiprocessing.MutexedNamespaceAutoProxy.
+        __enter__ = InstrumentBaseProxy.__enter__
+        __exit__ = InstrumentBaseProxy.__exit__
+        get_instrument_lib = Instrument.Proxy.get_instrument_lib
+        instrument_lib = Instrument.Proxy.instrument_lib
+        instrument = Instrument.Proxy.instrument
+
+
+SharedMemoryManager.register("CameraProxy", proxytype=Camera.Proxy, create_method=False)

--- a/catkit/interfaces/DeformableMirrorController.py
+++ b/catkit/interfaces/DeformableMirrorController.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
+from multiprocessing.managers import BaseProxy
 
 from catkit.interfaces.Instrument import Instrument
+from catkit.multiprocessing import SharedMemoryManager, MutexedNamespace
+
 """Interface for a deformable mirror controller that can control 2 DMs.  
    It does so by interpreting the first half of the command for DM1, and the second for DM2.
    This controller cannot control the two DMs independently, it will always send a command to both."""
@@ -15,3 +18,23 @@ class DeformableMirrorController(Instrument, ABC):
     @abstractmethod
     def apply_shape(self, dm_shape, dm_num):
         """Forms a command for a single DM, with zeros padded for the DM not in use."""
+
+    class Proxy(MutexedNamespace.Proxy):
+        _method_to_typeid_ = {"__enter__": "DeformableMirrorControllerProxy",
+                              "get_instrument_lib": "MutexedNamespaceAutoProxy",
+                              "get_mutex": "MutexProxy"}
+
+        __enter__ = Instrument.Proxy.__enter__
+        __exit__ = Instrument.Proxy.__exit__
+        get_instrument_lib = Instrument.Proxy.get_instrument_lib
+        instrument_lib = Instrument.Proxy.instrument_lib
+        instrument = Instrument.Proxy.instrument
+
+        def apply_shape_to_both(self, *args, **kwargs):
+            return self._callmethod("apply_shape_to_both", args=args, kwds=kwargs)
+
+        def apply_shape(self, *args, **kwargs):
+            return self._callmethod("apply_shape", args=args, kwds=kwargs)
+
+
+SharedMemoryManager.register("DeformableMirrorControllerProxy", proxytype=DeformableMirrorController.Proxy, create_method=False)

--- a/catkit/interfaces/DeformableMirrorController.py
+++ b/catkit/interfaces/DeformableMirrorController.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from multiprocessing.managers import BaseProxy
 
 from catkit.interfaces.Instrument import Instrument
-from catkit.multiprocessing import SharedMemoryManager, MutexedNamespace
+# from catkit.multiprocessing import SharedMemoryManager, MutexedNamespace
 
 """Interface for a deformable mirror controller that can control 2 DMs.  
    It does so by interpreting the first half of the command for DM1, and the second for DM2.
@@ -19,22 +19,23 @@ class DeformableMirrorController(Instrument, ABC):
     def apply_shape(self, dm_shape, dm_num):
         """Forms a command for a single DM, with zeros padded for the DM not in use."""
 
-    class Proxy(MutexedNamespace.Proxy):
-        _method_to_typeid_ = {"__enter__": "DeformableMirrorControllerProxy",
-                              "get_instrument_lib": "MutexedNamespaceAutoProxy",
-                              "get_mutex": "MutexProxy"}
-
-        __enter__ = Instrument.Proxy.__enter__
-        __exit__ = Instrument.Proxy.__exit__
-        get_instrument_lib = Instrument.Proxy.get_instrument_lib
-        instrument_lib = Instrument.Proxy.instrument_lib
-        instrument = Instrument.Proxy.instrument
-
-        def apply_shape_to_both(self, *args, **kwargs):
-            return self._callmethod("apply_shape_to_both", args=args, kwds=kwargs)
-
-        def apply_shape(self, *args, **kwargs):
-            return self._callmethod("apply_shape", args=args, kwds=kwargs)
-
-
-SharedMemoryManager.register("DeformableMirrorControllerProxy", proxytype=DeformableMirrorController.Proxy, create_method=False)
+#     # A "static" (non-autoproxy) proxy example. NOTE: Using this makes no difference to performance.
+#     class Proxy(MutexedNamespace.Proxy):
+#         _method_to_typeid_ = {"__enter__": "DeformableMirrorControllerProxy",
+#                               "get_instrument_lib": "MutexedNamespaceAutoProxy",
+#                               "get_mutex": "MutexProxy"}
+#
+#         __enter__ = Instrument.Proxy.__enter__
+#         __exit__ = Instrument.Proxy.__exit__
+#         get_instrument_lib = Instrument.Proxy.get_instrument_lib
+#         instrument_lib = Instrument.Proxy.instrument_lib
+#         instrument = Instrument.Proxy.instrument
+#
+#         def apply_shape_to_both(self, *args, **kwargs):
+#             return self._callmethod("apply_shape_to_both", args=args, kwds=kwargs)
+#
+#         def apply_shape(self, *args, **kwargs):
+#             return self._callmethod("apply_shape", args=args, kwds=kwargs)
+#
+#
+# SharedMemoryManager.register("DeformableMirrorControllerProxy", proxytype=DeformableMirrorController.Proxy, create_method=False)

--- a/catkit/interfaces/DeformableMirrorController.py
+++ b/catkit/interfaces/DeformableMirrorController.py
@@ -1,8 +1,7 @@
 from abc import ABC, abstractmethod
-from multiprocessing.managers import BaseProxy
 
-from catkit.interfaces.Instrument import Instrument
-# from catkit.multiprocessing import SharedMemoryManager, MutexedNamespace
+from catkit.interfaces.Instrument import Instrument, InstrumentBaseProxy
+from catkit.multiprocessing import SharedMemoryManager
 
 """Interface for a deformable mirror controller that can control 2 DMs.  
    It does so by interpreting the first half of the command for DM1, and the second for DM2.
@@ -19,23 +18,22 @@ class DeformableMirrorController(Instrument, ABC):
     def apply_shape(self, dm_shape, dm_num):
         """Forms a command for a single DM, with zeros padded for the DM not in use."""
 
-#     # A "static" (non-autoproxy) proxy example. NOTE: Using this makes no difference to performance.
-#     class Proxy(MutexedNamespace.Proxy):
-#         _method_to_typeid_ = {"__enter__": "DeformableMirrorControllerProxy",
-#                               "get_instrument_lib": "MutexedNamespaceAutoProxy",
-#                               "get_mutex": "MutexProxy"}
-#
-#         __enter__ = Instrument.Proxy.__enter__
-#         __exit__ = Instrument.Proxy.__exit__
-#         get_instrument_lib = Instrument.Proxy.get_instrument_lib
-#         instrument_lib = Instrument.Proxy.instrument_lib
-#         instrument = Instrument.Proxy.instrument
-#
-#         def apply_shape_to_both(self, *args, **kwargs):
-#             return self._callmethod("apply_shape_to_both", args=args, kwds=kwargs)
-#
-#         def apply_shape(self, *args, **kwargs):
-#             return self._callmethod("apply_shape", args=args, kwds=kwargs)
-#
-#
-# SharedMemoryManager.register("DeformableMirrorControllerProxy", proxytype=DeformableMirrorController.Proxy, create_method=False)
+    class PerformantProxy(InstrumentBaseProxy):
+        """ WARNING: This is not implicitly thread safe. See InstrumentBaseProxy for details.
+
+            NOTE: This proxy prevents referent introspection (aka attribute access) as InstrumentBaseProxy doesn't
+            inherit from NamespaceProxy.
+        """
+
+        _method_to_typeid_ = {"__enter__": "DeformableMirrorControllerPerformantProxy"}
+
+        def apply_shape_to_both(self, *args, **kwargs):
+            return self._callmethod("apply_shape_to_both", args=args, kwds=kwargs)
+
+        def apply_shape(self, *args, **kwargs):
+            return self._callmethod("apply_shape", args=args, kwds=kwargs)
+
+
+SharedMemoryManager.register("DeformableMirrorControllerPerformantProxy",
+                             proxytype=DeformableMirrorController.PerformantProxy,
+                             create_method=False)

--- a/catkit/interfaces/DummyContextManager.py
+++ b/catkit/interfaces/DummyContextManager.py
@@ -3,7 +3,7 @@ import logging
 
 class DummyContextManager(object):
 
-    log = logging.getLogger(__name__)
+    log = logging.getLogger()
 
     def __init__(self, config_id):
         self.config_id = config_id

--- a/catkit/interfaces/Instrument.py
+++ b/catkit/interfaces/Instrument.py
@@ -59,6 +59,10 @@ class InstrumentBaseProxy(AcquirerProxy):
         return self._callmethod("is_open")
 
     # AcquirerProxy.__enter__ calls acquire. We want to override their semantics to an open & close context.
+    # NOTE: If accessing via catkit.testbed.caching.DeviceCacheEnum, this is reverted back to acquire semantics.
+    # E.g.,
+    #      DeviceCacheEnum.MEMBER.__enter__() => Instrument.acquire()
+    #      DeviceCacheEnum.MEMBER().__enter__() => Instrument.__enter__()
     def __enter__(self, *args, **kwargs):
         return self._callmethod("__enter__", args=args, kwds=kwargs)
 

--- a/catkit/multiprocessing.py
+++ b/catkit/multiprocessing.py
@@ -627,16 +627,6 @@ class SharedMemoryManager(SyncManager):
 
     _Server = CatkitServer
 
-    # @classmethod
-    # def _run_server(cls, registry, address, authkey, serializer, writer, initializer=None, initargs=()):
-    #     """ This is run as process.target, i.e., on the server process. """
-    #     # NOTE: Explicitly ref SharedMemoryManager rather than cls such that derived classes mutate their base attrs.
-    #     SharedMemoryManager.is_a_server_process = True
-    #     SharedMemoryManager.server_address = address
-    #     SharedMemoryManager.server_pid = os.getpid()
-    #     return super()._run_server(registry, address, authkey, serializer, writer, initializer=initializer,
-    #                                initargs=initargs)
-
     def __init__(self, *args, address=None, timeout=DEFAULT_TIMEOUT, own=False, **kwargs):
         self.own = own  # Accessed by __del__ so hoist to here.
 

--- a/catkit/multiprocessing.py
+++ b/catkit/multiprocessing.py
@@ -30,7 +30,7 @@ class CatkitSocket(socket.socket):
             self.ioctl(socket.SIO_LOOPBACK_FAST_PATH, True)
 
 
-socket.socket = CatkitSocket
+#socket.socket = CatkitSocket
 
 
 class CatkitServer(Server):

--- a/catkit/multiprocessing.py
+++ b/catkit/multiprocessing.py
@@ -1,19 +1,148 @@
-from collections import namedtuple
+from collections import UserDict
+import logging
 import os
+import sys
 import threading
+
 
 # NOTE: "multiprocess" is a 3rd party package and not Python's own "multiprocessing".
 # https://github.com/uqfoundation/multiprocess is a fork of multiprocessing that uses "dill" instead of "pickle".
-from multiprocess import get_context, get_logger, TimeoutError
-from multiprocess.managers import AcquirerProxy, BarrierProxy, Namespace, NamespaceProxy, State, \
-    SyncManager, ValueProxy
+import multiprocess.util as util
+from multiprocess import get_context, TimeoutError
+from multiprocess.managers import AcquirerProxy, AutoProxy, BarrierProxy, DictProxy, EventProxy, \
+    NamespaceProxy, Server, State, SyncManager, ValueProxy, Token, format_exc
 
 
 DEFAULT_TIMEOUT = 60
+
+# TODO: When using servers across networked machines, the loopback IP won't be viable.
 DEFAULT_SHARED_MEMORY_SERVER_ADDRESS = ("127.0.0.1", 6000)  # IP, port.
+EXCEPTION_SERVER_ADDRESS = ("127.0.0.1", 6001)  # IP, port.
 
 CONTEXT_METHOD = "spawn"
 CONTEXT = get_context(CONTEXT_METHOD)
+
+
+class CatkitServer(Server):
+
+    # Patch to allow all funcs to be callable without needing to be pre-defined as exposed.
+    # This is necessary to dynamically create auto proxies, e.g., particularly those for the devices.
+    def serve_client(self, conn):
+        '''
+        Handle requests from the proxies in a particular process/thread
+        '''
+        util.debug('starting server thread to service %r',
+                   threading.current_thread().name)
+
+        recv = conn.recv
+        send = conn.send
+        id_to_obj = self.id_to_obj
+
+        while not self.stop_event.is_set():
+            try:
+                methodname = obj = None
+                request = recv()
+                ident, methodname, args, kwds = request
+                try:
+                    obj, exposed, gettypeid = id_to_obj[ident]
+                except KeyError as ke:
+                    try:
+                        obj, exposed, gettypeid = \
+                            self.id_to_local_proxy_obj[ident]
+                    except KeyError as second_ke:
+                        raise ke
+
+                #--------BEGIN PATCH-----------
+                # if methodname not in exposed:
+                #     raise AttributeError(
+                #         'method %r of %r object is not in exposed=%r' %
+                #         (methodname, type(obj), exposed)
+                #     )
+                #----------END PATCH-----------
+
+                #--------BEGIN PATCH-----------
+                function = getattr(obj, methodname)  # <-- original
+                #function = operator.attrgetter(methodname)(obj)
+                #----------END PATCH-----------
+
+                try:
+                    #--------BEGIN PATCH-----------
+                    # if not hasattr(function, "__self__"):
+                    #     # Unbound method so self needs to be explicitly passed.
+                    #     args = (obj, *args)
+                    #----------END PATCH-----------
+                    res = function(*args, **kwds)
+
+                except Exception as e:
+                    msg = ('#ERROR', e)
+                else:
+                    typeid = gettypeid and gettypeid.get(methodname, None)
+                    #--------BEGIN PATCH-----------
+                    # if isinstance(typeid, dict):
+                    #     typeid = typeid.get(args, None)
+                    #----------END PATCH-----------
+
+                    if typeid:
+                        rident, rexposed = self.create(conn, typeid, res)
+                        token = Token(typeid, self.address, rident)
+                        msg = ('#PROXY', (rexposed, token))
+                    else:
+                        msg = ('#RETURN', res)
+
+            except AttributeError:
+                if methodname is None:
+                    msg = ('#TRACEBACK', format_exc())
+                else:
+                    try:
+                        fallback_func = self.fallback_mapping[methodname]
+                        result = fallback_func(
+                            self, conn, ident, obj, *args, **kwds
+                        )
+                        msg = ('#RETURN', result)
+                    except Exception:
+                        msg = ('#TRACEBACK', format_exc())
+
+            except EOFError:
+                util.debug('got EOF -- exiting thread serving %r',
+                           threading.current_thread().name)
+                sys.exit(0)
+
+            except Exception:
+                msg = ('#TRACEBACK', format_exc())
+
+            try:
+                try:
+                    send(msg)
+                except Exception as e:
+                    send(('#UNSERIALIZABLE', format_exc()))
+            except Exception as e:
+                util.info('exception in thread serving %r',
+                          threading.current_thread().name)
+                util.info(' ... message was %r', msg)
+                util.info(' ... exception was %r', e)
+                conn.close()
+                sys.exit(1)
+
+    # Patch this to correctly handle properties.
+    def all_methods(obj):
+        '''
+        Return a list of names of methods of `obj`
+        '''
+        temp = []
+        for name in dir(obj):
+            #--------BEGIN PATCH-----------
+            # Properties must be checked on the class and not the instance object such that they aren't called.
+            cls = getattr(obj, "__class__", None)
+            if cls:
+                func = getattr(cls, name, None)
+                if func and isinstance(func, property):
+                    continue
+            #----------END PATCH-----------
+
+            func = getattr(obj, name)
+            if callable(func):
+                temp.append(name)
+        return temp
 
 
 class Process(CONTEXT.Process):
@@ -22,52 +151,102 @@ class Process(CONTEXT.Process):
             This is executed on the child process.
         """
         try:
+            pid = self.pid
+            assert pid
             super().run()
         except Exception as error:
+            manager = SharedMemoryManager(address=EXCEPTION_SERVER_ADDRESS)
             try:  # Manager may not have been started.
-                manager = SharedMemoryManager()
                 manager.connect()
-                manager.set_exception(self.pid, error)
+            except Exception:
+                pass
+            else:
+                manager.set_exception(pid, error)
+                assert manager.get_exception(pid)
+
             finally:
                 raise error
 
-    def join(self):
+    def join(self, timeout=None):
         """ Join and raise saved exception if one occurred.
             This is executed on the parent process.
         """
-        super().join()
-        if not self.exitcode:
+        pid = self.pid
+        super().join(timeout)
+        exitcode = self.exitcode
+        if exitcode == 0:
             return
-
-        child_exception = None
-        try:  # Manager may not have been started.
-            manager = SharedMemoryManager()
-            manager.connect()
-            child_exception = manager.get_exception(self.pid)
-        except Exception:
-             pass
-
-        if child_exception:
-            # Raise the child exception rather than chaining, to facilitate better options for subsequent exception
-            # handling.
-            raise child_exception
+        elif exitcode is None:
+            # Process is still running.
+            raise TimeoutError(f"The process '{self.name}' on PID {self.pid} failed to join after {timeout} seconds")
         else:
-            raise Exception(f"Child process ('{self.name}' with pid: '{self.pid}') exited with non-zero exitcode: '{self.exitcode}'")
+            child_exception = None
+            manager = SharedMemoryManager(address=EXCEPTION_SERVER_ADDRESS)
+            try:  # Manager may not have been started.
+                manager.connect()
+            except Exception:
+                pass
+            else:
+                child_exception = manager.get_exception(pid)  # Returns None if pid not in dict.
+
+            if child_exception:
+                # Raise the child exception rather than chaining, to facilitate better options for subsequent exception
+                # handling.
+                raise child_exception
+            else:
+                raise Exception(f"Child process ('{self.name}' with pid: '{self.pid}') exited with non-zero exitcode: '{self.exitcode}'")
+
+
+""" There are two main mutex patterns in use here; proxy only mutexes and referent mutexes.
+    referent mutexes are those where access to the referent (from the server) are mutexed, e.g., __getattribute__() is
+    mutexed. Proxy only mutexes are where the referent is mutexed only by the proxy, i.e., from the client.
+    
+    Proxy only mutexes are weaker as they require strict API usage such that all referent access is via a proxy, E.g.,
+    as is the case for device access via the device enum API. The advantage is that the referent object class requires
+    no alterations, e.g., inserting a mutex. However, any indirect access, i.e., from the server will not be mutexed and
+    can by-pass any proxy client-side mutex. Again, strict API usage is required.
+    
+    Referent mutex is where any and all access is mutexed as is mutexed from server-side access. This accounts for
+    indirect access, e.g., a device proxy calling a method that obviously gets executed server-side and then access the,
+    for example, the shared simulator object. Without a referent mutex a global lock of the sim object, from some
+    client, will fail to lock all access as it will only lock (direct) proxy access.
+"""
 
 
 class Mutex:
-    """ A container for a shared re-entrant lock.
+    """ A container for a shared (reentrant) lock. """
 
-        NOTE: For this to be actually shared it is subsequently registered with
-        catkit.multirocessing.SharedMemoryManager and must be instantiated from a running/connected instance of
-        catkit.multirocessing.SharedMemoryManager.
-    """
+    __slots__ = ("_catkit_mutex", "_catkit_mutex_id", "timeout")#, "from_pid", "_count")
 
-    def __init__(self, *args, lock=None, timeout=DEFAULT_TIMEOUT, **kwargs):
+    def __init__(self, *args, lock=None, timeout=None, **kwargs):
         super().__init__(*args, **kwargs)
-        lock = threading.RLock() if lock is None else lock
-        self.lock = lock.lock if isinstance(lock, Mutex) else lock
-        self.timeout = timeout
+
+        # self.from_pid = None
+        # self._count = 0
+
+        if lock is None:
+            self._catkit_mutex = threading.RLock()
+            self._catkit_mutex_id = id(self._catkit_mutex)
+            self.timeout = DEFAULT_TIMEOUT if timeout is None else timeout
+        elif isinstance(lock, (type(threading.RLock()), type(threading.Lock()))):
+            self._catkit_mutex = lock
+            self._catkit_mutex_id = id(self._catkit_mutex)
+            self.timeout = DEFAULT_TIMEOUT if timeout is None else timeout
+        elif isinstance(lock, Mutex):
+            self._catkit_mutex = lock.get_mutex()
+            self._catkit_mutex_id = lock.get_mutex_id()
+            assert id(self._catkit_mutex) == self._catkit_mutex_id
+            self.timeout = lock.timeout if timeout is None else timeout
+        elif isinstance(lock, Mutex.Proxy):
+            self._catkit_mutex = lock
+            self._catkit_mutex_id = self._catkit_mutex.get_mutex_id()
+            self.timeout = lock.timeout if timeout is None else timeout
+        else:
+            raise TypeError()
+
+    def __eq__(self, other):
+        other = other.get_mutex_id() if isinstance(other, (Mutex, Mutex.Proxy)) else id(other)
+        return self.get_mutex_id() == other
 
     def acquire(self, timeout=None, raise_on_fail=True):
         """
@@ -78,13 +257,17 @@ class Mutex:
         if timeout is None:
             timeout = self.timeout
 
-        locked = self.lock.acquire(timeout=timeout)
-        if raise_on_fail and not locked:
-            raise TimeoutError(f"Failed to acquire lock after {timeout}s")
+        locked = self._catkit_mutex.acquire(timeout=timeout)
+        if not locked and raise_on_fail:
+            raise TimeoutError(f"Failed to acquire lock after {timeout}s (exec on (not from) PID: {os.getpid()}, ID: {self._catkit_mutex_id:#x})")
+
+        # if locked:
+        #     self._count += 1
         return locked
 
     def release(self):
-        return self.lock.release()
+        # self._count -= 1
+        return self._catkit_mutex.release()
 
     def __enter__(self):
         return self.acquire()
@@ -92,12 +275,147 @@ class Mutex:
     def __exit__(self, exc_type, exc_val, exc_tb):
         return self.release()
 
-    class Proxy(AcquirerProxy):
+    def get_mutex(self):
+        return self._catkit_mutex
+
+    def get_mutex_id(self):
+        return self._catkit_mutex_id
+
+    #@lru_cache(maxsize=None)
+    def clobber(self, new_mutex):
+        old_mutex = self._catkit_mutex
+        with old_mutex:  # Acquire to ensure nothing else has it before we clobber it.
+            self._catkit_mutex = new_mutex
+
+    class Proxy(NamespaceProxy, AcquirerProxy):
+        _exposed_ = ("__eq__", "clobber", "get_mutex_id", *NamespaceProxy._exposed_, *AcquirerProxy._exposed_)
+        _method_to_typeid_ = {"get_mutex": "MutexProxy"}
+
         def acquire(self, *args, **kwargs):
-            return self._callmethod('acquire', args, kwargs)  # Don't unpack.
+            # NOTE: Override since the original signature is constrained.
+            return self._callmethod("acquire", args, kwargs)
+
+        def __enter__(self):
+            # NOTE: Override so that it calls the above custom acquire.
+            return self.acquire()
+
+        def clobber(self, *args, **kwargs):
+            return self._callmethod("clobber", args, kwargs)
+
+        def __eq__(self, *args, **kwargs):
+            return self._callmethod("__eq__", args, kwargs)
+
+        def get_mutex(self):
+            return self._callmethod("get_mutex")
+
+        def get_mutex_id(self):
+            return self._callmethod("get_mutex_id")
 
 
-class MutexedSingletonNamespace:
+class Namespace(object):
+
+    # Patch the following to allow for inheritance - functionality of the src isn't required.
+    # def __init__(self, **kwds):
+    #     self.__dict__.update(kwds)
+
+    def __repr__(self):
+        items = list(self.__dict__.items())
+        temp = []
+        for name, value in items:
+            if not name.startswith('_'):
+                temp.append('%s=%r' % (name, value))
+        temp.sort()
+        return '%s(%s)' % (self.__class__.__name__, ', '.join(temp))
+
+
+class MutexedNamespace(Namespace):  # MutexedObject
+    """ Base class for a mutexed object.
+        NOTE: Methods are not mutexed server-side so this is not completely thread-safe. They are however, mutexed
+        proxy-side so are "thread-safe" within the context of the shared memory manager model.
+    """
+
+    __slots__ = ("_catkit_mutex",)  # __dict__ still exists from the base, otherwise we'd have a 1 attr namespace!
+
+    def __new__(cls, *args, lock=None, timeout=None, **kwargs):
+        obj = super().__new__(cls)
+
+        # Init mutex.
+        if timeout is None and hasattr(cls, "timeout"):
+            timeout = cls.timeout
+        object.__setattr__(obj, "_catkit_mutex", Mutex(lock=lock, timeout=timeout))
+        return obj
+
+    def __init__(self, *args, lock=None, timeout=None, **kwargs):
+        # NOTE: lock & timeout are only required for __new__ so we remove them and don't pass them to super.
+        super().__init__(*args, **kwargs)
+
+    def copy_from(self, other):
+        self.__dict__.update(other.__dict__.copy())
+
+    def __getattribute__(self, item):
+        with object.__getattribute__(self, "_catkit_mutex"):
+            return object.__getattribute__(self, item)
+
+    def __setattr__(self, name, value):
+        with self._catkit_mutex:
+            return super().__setattr__(name, value)
+
+    def __delattr__(self, item):
+        with self._catkit_mutex:
+            return super().__delattr__(item)
+
+    def __enter__(self):
+        return object.__getattribute__(self, "_catkit_mutex").__enter__()
+
+    def __exit__(self, *args, **kwargs):
+        return object.__getattribute__(self, "_catkit_mutex").__exit__(*args, **kwargs)
+
+    def acquire(self, *args, **kwargs):
+        return object.__getattribute__(self, "_catkit_mutex").acquire(*args, **kwargs)
+
+    def release(self, *args, **kwargs):
+        return object.__getattribute__(self, "_catkit_mutex").release(*args, **kwargs)
+
+    def get_mutex(self):
+        return object.__getattribute__(self, "_catkit_mutex")
+
+    def clobber_mutex(self, *args, **kwargs):
+        return object.__getattribute__(self, "_catkit_mutex").clobber(*args, **kwargs)
+
+    class Proxy(Mutex.Proxy, NamespaceProxy):
+
+        _exposed_ = ("getpid", *Mutex.Proxy._exposed_, *NamespaceProxy._exposed_)
+        # NOTE: The following are either mutexed server-side (so there's no need to do so from the proxy) or they just
+        # shouldn't be mutexed at all, i.e., anything that would block/delay a concurrent acquire attempt (e.g.,
+        # "__init__" and "acquire").
+        _DONT_PROXY_MUTEX = ("__getattribute__", "__setattr__", "__delattr__", "__enter__", "__exit__", "acquire",
+                             "release", "clobber_mutex", "get_mutex", "get_mutex_id", "__init__")
+
+        def clobber_mutex(self, *args, **kwargs):
+            return self._callmethod("clobber", args=args, kwds=kwargs)
+
+        def _callmethod(self, methodname, args=(), kwds={}):
+            # Don't lock server-side mutexed methods.
+            if methodname in object.__getattribute__(self, "_DONT_PROXY_MUTEX"):
+                return super()._callmethod(methodname, args=args, kwds=kwds)
+
+            # NOTE: The context management funcs __enter__ & __exit__ may be overridden, e.g., as they are for
+            # Instrument. Given that proxies can't be passed to the server from client and back again whilst maintaining
+            # their manager (as it can't be pickled) we need an explicit route to mutex without having to first retrieve
+            # a mutex proxy - because that would require a manager for which there may not be one. So instead of using
+            # ``with self.get_mutex():`` we do the following.
+            is_locked = super()._callmethod("acquire")
+            try:
+                return super()._callmethod(methodname, args=args, kwds=kwds)
+            finally:
+                if is_locked:
+                    super()._callmethod("release")
+
+        def getpid(self):
+            return self._manager.getpid()
+
+
+class MutexedNamespaceSingleton(MutexedNamespace):
 
     """ A child of the above Mutex and multiprocess.managers.Namespace implemented as a singleton.
 
@@ -113,72 +431,169 @@ class MutexedSingletonNamespace:
         1) Create a subclass of the manager with the addition of a new attribute that will be instantiated on the
            server and and accessible via registered funcs.
            As exampled by catkit.multiprocessing.SharedMemoryManager.cache_lock.
-        2) Create a subclass of MutexedSingletonNamespace and register it such that the registered
+        2) Create a subclass of MutexedNamespaceSingleton using its factor method such that the registered
            TypeID will be the universal ID accessible from any client.
-           As exampled by catkit.multiprocessing.SharedMemoryManager().shared_state().
+           As exampled by catkit.multiprocessing.SharedMemoryManager().SharedState().
     """
 
     instance = None
 
-    # Namespace.__init__() takes only **kwargs so we're forced to use this inheritance order (not that it would matter).
-    class _MutexedSingletonNamespace(Mutex, Namespace):
-        pass
+    def __new__(cls, *args, address=None, disable_shared_memory=False, **kwargs):
+        if cls.instance is None:
+            if (not disable_shared_memory) and (address is not None or hasattr(cls, "address")):
+                # Shared usage.
 
-    def __new__(cls, *args, **kwargs):
-        if not cls.instance:
-            cls.instance = cls._MutexedSingletonNamespace(*args, **kwargs)
+                if address is None and hasattr(cls, "address"):
+                    address = cls.address
+
+                if SharedMemoryManager.is_a_server_process and address == SharedMemoryManager.server_address:
+                    # This is server-side.
+                    obj = super().__new__(cls, *args, **kwargs)
+                else:
+                    # This is client-side.
+                    manager = SharedMemoryManager(address=address)
+                    manager.connect()
+                    obj = getattr(manager, cls.__name__)(*args, **kwargs)  # This will be a proxy.
+                    # NOTE: Since cls.instance is a proxy and neither an instance nor subclass of cls, __init__() will
+                    # NOT be called implicitly post __new__().
+                    #assert isinstance(cls.instance, BaseProxy), type(cls.instance)
+            else:
+                # Local usage.
+                obj = super().__new__(cls, *args, **kwargs)
+
+            # NOTE: cls(*args, **kwargs) -> cls.__new__(cls).__init__(*args, **kwargs) when
+            # isinstance(cls.__new__(cls), cls) and  cls.__new__(cls) otherwise.
+            # I.e., __init__ is only implicitly called when __new__ returns an instance (or subclass) of its own class.
+            # It therefore won't be called when a proxy is returned as desired.
+            # However, this interferes with the singleton pattern and use of factory so we implicitly call __init__ here
+            # before assigning to cls.instance, which __init__ uses as a condition on whether to be a NOOP. Using an
+            # instance attribute as a NOOP flag would block if the object is locked and thus prevent even a proxy
+            # retrieval of the remote object.
+            if isinstance(obj, cls) or issubclass(obj.__class__, cls):
+                obj.__init__(*args, **kwargs)
+
+            # NOTE: The server mutexes its creation func from which this func is called thus mitigating the race
+            # condition between ``if cls.instance is None:``, ``obj = super().__new__()``, and its assignment to
+            # ``cls.instance``.
+            cls.instance = obj
+
         return cls.instance
 
-    # __getattr__ & __setattr__ should explicitly NOT be mutexed as reentrant locks are only reentrant from the same
-    # process and these will get executed server-side, which would cause a timeout/deadlock.
-    def __getattr__(self, name):
-        return self.instance.__getattribute__(name)
+    def __init__(self, *args, **kwargs):
+        # NOTE: We only want to initialize the singleton instance once (see notes in __new__ for more details).
+        if object.__getattribute__(self, "__class__").instance is None:
+            super().__init__(*args, **kwargs)
 
-    def __setattr__(self, name, value):
-        return object.__setattr__(self.instance, name, value)
+    class Proxy(MutexedNamespace.Proxy):
+        pass
 
-    # Proxy (client-side) access needs to be mutexed though the mutex doesn't belong to the proxy instance but the
-    # server-side referent. The manager mutexes access on the server, however, we wish to expose a mutex to the client
-    # such that multiple accesses can be mutexed.
-    class Proxy(Mutex.Proxy, NamespaceProxy):
-        _exposed_ = ('__getattribute__', '__setattr__', '__delattr__', 'acquire', 'release')
+    @classmethod
+    def factory(cls, address=None, name=None, timeout=None, new_class_dict={}):
+        NewClass = type(name if name else "NewClass", (cls,), dict(instance=None,
+                                                                   address=address,
+                                                                   timeout=timeout,
+                                                                   **new_class_dict))
+        # Register the class with the server manager.
+        # NOTE: Any class modification beyond this block will not be propagated to the server.
+        if address:
+            if name:
+                # Registering classes with the server must happen before it is started.
+                manager = SharedMemoryManager(address=address)
+                try:
+                    manager.connect()
+                except ConnectionRefusedError:
+                    # This is ok, the manager (probably) hasn't been started yet.
+                    SharedMemoryManager.register(name, callable=NewClass, proxytype=NewClass.Proxy, create_method=True)
+                else:
+                    # The manager was able to connect which means that the server has already been started.
+                    SharedMemoryManager.register(name, proxytype=NewClass.Proxy, create_method=True)
+                finally:
+                    del manager
+            else:
+                raise ValueError(f"Remote access requires a str name to register with {SharedMemoryManager.__qualname__}.")
 
-        # Copied from NamespaceProxy (with added mutex).
-        def __getattr__(self, key):
-            if key[0] == '_':
-                return object.__getattribute__(self, key)
+        return NewClass
+
+
+# class AutoProxyBase:
+#     def __new__(cls, *args, **kwargs):
+#         return AutoProxy(*args, **kwargs)
+#
+#
+# class MutexedNamespaceAutoProxy(MutexedNamespace.Proxy, AutoProxyBase):
+#     pass
+
+
+class MutexedNamespaceAutoProxy:
+    """ This is a combination of mutliprocess.managers.AutoProxy and MutexedNamespaceSingleton.Proxy
+        This is proxy used by Instrument.Proxy.
+    """
+    # NOTE: This class allows only partial inheritance.
+
+    # NOTE: _method_to_typeid_ needs to be in place pre-registration.
+    _method_to_typeid_ = {**MutexedNamespace.Proxy._method_to_typeid_}
+
+    def __init__(self, *args, **kwargs):
+        """ Sanity checking that this isn't being called post __new__(). """
+        assert False
+
+    def __new__(cls, *args, **kwargs):
+        proxy_obj = AutoProxy(*args, **kwargs)
+        proxy_type = type(proxy_obj)
+
+        proxy_obj._exposed_ = [*proxy_obj._exposed_, *MutexedNamespace.Proxy._exposed_]
+        if hasattr(cls, "_exposed_"):
+            proxy_obj._exposed_.extend(cls._exposed_)
+
+        # NOTE: It's too late for this here as it needs to be done pre-registration such that it's accurate on the
+        # server. However, still do so for client side correctness.
+        if hasattr(proxy_obj, "_method_to_typeid_"):
+            proxy_obj._method_to_typeid_.update(cls._method_to_typeid_)
+        else:
+            proxy_obj._method_to_typeid_ = cls._method_to_typeid_
+        if hasattr(cls, "_method_to_typeid_"):
+            proxy_obj._method_to_typeid_.update(cls._method_to_typeid_)
+
+        proxy_obj._DONT_PROXY_MUTEX = MutexedNamespace.Proxy._DONT_PROXY_MUTEX
+
+        proxy_obj.__class__.__enter__ = MutexedNamespace.Proxy.__enter__
+        proxy_obj.__class__.__exit__ = MutexedNamespace.Proxy.__exit__
+        proxy_obj.__class__.__delattr__ = MutexedNamespace.Proxy.__delattr__
+        proxy_obj.__class__.__getattr__ = MutexedNamespace.Proxy.__getattr__
+        proxy_obj.__class__.__setattr__ = MutexedNamespace.Proxy.__setattr__
+        proxy_obj.__class__.__eq__ = MutexedNamespace.Proxy.__eq__
+        proxy_obj.__class__.acquire = MutexedNamespace.Proxy.acquire
+        proxy_obj.__class__.release = MutexedNamespace.Proxy.release
+        proxy_obj.__class__.get_mutex = MutexedNamespace.Proxy.get_mutex
+        proxy_obj.__class__.get_mutex_id = MutexedNamespace.Proxy.get_mutex_id
+
+        def _callmethod(self, methodname, args=(), kwds={}):
+            """ A copy of MutexedNamespace.Proxy._callmethod with added super() specification. """
+            # Don't re-lock already server-side-mutexed methods.
+            if methodname in object.__getattribute__(self, "_DONT_PROXY_MUTEX"):
+                return super(proxy_type, self)._callmethod(methodname, args=args, kwds=kwds)
+
+            # NOTE: See note in MutexedNamespace.Proxy._callmethod for try-except usage here.
+            is_locked = super(proxy_type, self)._callmethod("acquire")
             try:
-                locked = None
-                locked = object.__getattribute__(self, "__enter__")()
-                callmethod = object.__getattribute__(self, '_callmethod')
-                return callmethod('__getattribute__', (key,))
+                return super(proxy_type, self)._callmethod(methodname, args=args, kwds=kwds)
             finally:
-                if locked:
-                    object.__getattribute__(self, "__exit__")(None, None, None)
+                if is_locked:
+                    super(proxy_type, self)._callmethod("release")
 
-        def __setattr__(self, key, value):
-            if key[0] == '_':
-                return object.__setattr__(self, key, value)
-            try:
-                locked = None
-                locked = object.__getattribute__(self, "__enter__")()
-                callmethod = object.__getattribute__(self, '_callmethod')
-                return callmethod('__setattr__', (key, value))
-            finally:
-                if locked:
-                    object.__getattribute__(self, "__exit__")(None, None, None)
+        proxy_obj.__class__._callmethod = _callmethod
 
-        def __delattr__(self, key):
-            if key[0] == '_':
-                return object.__delattr__(self, key)
-            try:
-                locked = None
-                locked = object.__getattribute__(self, "__enter__")()
-                callmethod = object.__getattribute__(self, '_callmethod')
-                return callmethod('__delattr__', (key,))
-            finally:
-                if locked:
-                    object.__getattribute__(self, "__exit__")(None, None, None)
+        # Inheritance.
+        if cls is not MutexedNamespaceAutoProxy:
+            cls_dict = cls.__dict__.copy()
+            if "_exposed_" in cls_dict:
+                del cls_dict["_exposed_"]
+            if "_method_to_typeid_" in cls_dict:
+                del cls_dict["_method_to_typeid_"]
+            for key, value in cls_dict.items():
+                 setattr(proxy_obj.__class__, key, value)
+
+        return proxy_obj
 
 
 class SharedMemoryManager(SyncManager):
@@ -201,60 +616,66 @@ class SharedMemoryManager(SyncManager):
         If True, shutdown() will get called upon deletion.
     """
 
-    def __init__(self, *args, address=DEFAULT_SHARED_MEMORY_SERVER_ADDRESS, timeout=DEFAULT_TIMEOUT, own=False, **kwargs):
-        super().__init__(*args, address=address, **kwargs)
-        self.log = get_logger()
+    # Pattern to know whether this is a server or client process: Since we're using spawn there will be an import of
+    # of this module/process and thus an class def for this cls per process. Therefore, ``is_server_side`` will remain
+    # False until ``_run_server()`` is called on a server process and mutates its static class attribute. However,
+    # server procs may need to comm with one another so this proc may not be that of the desired server.
+    # `server_address` is therefore used to disambiguate.
+    is_a_server_process = False
+    server_address = None
+    server_pid = None
+
+    _Server = CatkitServer
+
+    # @classmethod
+    # def _run_server(cls, registry, address, authkey, serializer, writer, initializer=None, initargs=()):
+    #     """ This is run as process.target, i.e., on the server process. """
+    #     # NOTE: Explicitly ref SharedMemoryManager rather than cls such that derived classes mutate their base attrs.
+    #     SharedMemoryManager.is_a_server_process = True
+    #     SharedMemoryManager.server_address = address
+    #     SharedMemoryManager.server_pid = os.getpid()
+    #     return super()._run_server(registry, address, authkey, serializer, writer, initializer=initializer,
+    #                                initargs=initargs)
+
+    def __init__(self, *args, address=None, timeout=DEFAULT_TIMEOUT, own=False, **kwargs):
+        self.own = own  # Accessed by __del__ so hoist to here.
+
+        if address is None:
+            address = self.ADDRESS if hasattr(self, "ADDRESS") else DEFAULT_SHARED_MEMORY_SERVER_ADDRESS
+
+        # NOTE: The context is set here.
+        super().__init__(*args, address=address, ctx=CONTEXT, **kwargs)
+        self.log = logging.getLogger()
         self.server_pid = None
-        self.own = own
+        self.timeout = timeout
 
-        # Server-side non-shared non-reentrant lock to protect against any possible server-side threading.
-        self.master_lock = Mutex(lock=threading.Lock(), timeout=timeout)
+        self.lock_cache = None
+        self.barrier_cache = None
+        self.event_cache = None
+        self.child_process_exceptions = None
 
-        self.lock_cache = {}  # Cache for all locks (local dummy - don't access directly).
-        self.barrier_cache = {}  # Cache for all barriers (local dummy - don't access directly).
-        self.child_process_exceptions = {}  # Used to pass exceptions back to parent.
+        self.initargs = [address]
 
-        # Nothing is stored in the above (local) instances, they are copied to the server and must then be accessed by
-        # the following registered funcs.
+    @staticmethod
+    def initializer(address):
+        """ Make "initializer" a func such that multiples can be defined via class inheritance.
+            NOTE: self.initargs are the args that get passed to this func by self.start() and are called by the child
+                  process as initializer(*initargs), therefore, the order of self.initargs matters.
+        """
 
-        def get_lock(name, timeout=DEFAULT_TIMEOUT):
-            # NOTE: This is registered below and will get executed server-side.
-            with self.master_lock:
-                if name not in self.lock_cache:
-                    self.lock_cache.update({name: Mutex(lock=threading.RLock(), timeout=timeout)})
-                return self.lock_cache.get(name)
+        # NOTE: Explicitly ref SharedMemoryManager rather than cls such that derived classes mutate their base attrs.
+        SharedMemoryManager.is_a_server_process = True
+        SharedMemoryManager.server_address = address
+        SharedMemoryManager.server_pid = os.getpid()
 
-        def get_barrier(name, parties, action=None, timeout=DEFAULT_TIMEOUT):
-            # NOTE: This is registered below and will get executed server-side.
-            with self.master_lock:
-                if name not in self.barrier_cache:
-                    self.barrier_cache.update({name: threading.Barrier(parties=parties,
-                                                                       action=action,
-                                                                       timeout=timeout)})
-                return self.barrier_cache.get(name)
+    def start(self, initializer=None, initargs=None):
 
-        # Registered funcs get executed server side.
-        self.register("_getpid", callable=os.getpid, proxytype=ValueProxy)  # This will return the PID of the server.
-        self.register("get_lock", callable=get_lock, proxytype=Mutex.Proxy)
-        self.register("get_barrier", callable=get_barrier, proxytype=BarrierProxy)
+        if initializer is not None or initargs is not None:
+            raise TypeError("Don't pass `initializer` and `initargs` to start(). Instead define `cls.initializer` and `self.initargs`.")
 
-        def set_exception(pid, exception):
-            self.child_process_exceptions[pid] = exception
-
-        self.register("set_exception", callable=set_exception)
-        self.register("_get_exception", callable=lambda pid: self.child_process_exceptions.get(pid), proxytype=ValueProxy)
-
-    def getpid(self):
-        return self._getpid()._getvalue()
-
-    def get_exception(self, pid):
-        return self._get_exception(pid)._getvalue()
-
-    def start(self, *args, **kwargs):
-        ret = super().start(*args, **kwargs)
+        super().start(initializer=self.initializer, initargs=self.initargs)
         self.server_pid = self.getpid()
         self.log.info(f"Shared memory manager started on PID: '{self.server_pid}'")
-        return ret
 
     def shutdown(self):
         # Whilst super().shutdown() can be called multiple times, the method doesn't even exist until
@@ -265,17 +686,132 @@ class SharedMemoryManager(SyncManager):
     def __del__(self):
         if self.own:
             self.shutdown()
+
         if getattr(super(), "__del__", None):
             super().__del__()
 
+    def getpid(self):
+        return self._getpid()._getvalue()
 
-SharedMemoryManager.register("Mutex", callable=Mutex, proxytype=Mutex.Proxy)
+    def get_exception(self, pid):
+        if self.child_process_exceptions is None:
+            self.child_process_exceptions = self._ExceptionCache()
+
+        with self.child_process_exceptions:
+            return self.child_process_exceptions.get(pid, None)
+
+    def set_exception(self, pid, exception):
+        if self.child_process_exceptions is None:
+            self.child_process_exceptions = self._ExceptionCache()
+
+        with self.child_process_exceptions:
+            self.child_process_exceptions.update({pid: exception})
+
+    def get_lock(self, name, timeout=None):
+        if timeout is None:
+            timeout = self.timeout
+
+        if self.lock_cache is None:
+            self.lock_cache = self._LockCache()
+
+        with self.lock_cache:
+            if name not in self.lock_cache:
+                lock_proxy = self.Mutex(timeout=timeout)
+                self.lock_cache.update({name: lock_proxy})
+                return lock_proxy
+            else:
+                return self.lock_cache.get(name)
+
+    def get_barrier(self, name, parties, action=None, timeout=None):
+        # NOTE: Barriers are keyed only by name.
+        if timeout is None:
+            timeout = self.timeout
+
+        if self.barrier_cache is None:
+            self.barrier_cache = self._BarrierCache()
+
+        with self.barrier_cache:
+            if name not in self.barrier_cache:
+                barrier_proxy = self.Barrier(parties=parties, action=action, timeout=timeout)
+                self.barrier_cache.update({name: barrier_proxy})
+                return barrier_proxy
+            else:
+                return self.barrier_cache[name]
+
+    def get_event(self, name):
+        if self.event_cache is None:
+            self.event_cache = self._EventCache()
+
+        with self.event_cache:
+            if name not in self.event_cache:
+                event_proxy = self.Event()
+                self.event_cache.update({name: event_proxy})
+                return event_proxy
+            else:
+                return self.event_cache[name]
 
 
-class SharedState(MutexedSingletonNamespace):
-    pass
+class _PseudoMutexedDictSingleton:
+    instance = None
+
+    class _PseudoMutexedDict(UserDict):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._mutex = threading.Lock()
+
+        def acquire(self):
+            self._mutex.acquire()
+
+        def release(self):
+            self._mutex.release()
+
+    def __new__(cls, *args, **kwargs):
+        if cls.instance is None:
+            cls.instance = cls._PseudoMutexedDict(*args, **kwargs)
+        return cls.instance
+
+    def __init__(self):
+        assert False
+
+    class Proxy(AcquirerProxy, DictProxy):
+        pass
 
 
-# Then make the above namespace object `SharedState` accessible from any client via
-# `SharedMemoryManager().connect().SharedState()`:
-SharedMemoryManager.register("SharedState", callable=SharedState, proxytype=SharedState.Proxy)
+class _LockCache(_PseudoMutexedDictSingleton):
+    instance = None
+
+
+class _BarrierCache(_PseudoMutexedDictSingleton):
+    instance = None
+
+
+class _EventCache(_PseudoMutexedDictSingleton):
+    instance = None
+
+
+class _ExceptionCache(_PseudoMutexedDictSingleton):
+    instance = None
+
+
+# Registered types intended for internal use only.
+SharedMemoryManager.register("_LockCache", callable=_LockCache, proxytype=_LockCache.Proxy, create_method=True)
+SharedMemoryManager.register("_BarrierCache", callable=_BarrierCache, proxytype=_BarrierCache.Proxy, create_method=True)
+SharedMemoryManager.register("_EventCache", callable=_EventCache, proxytype=_EventCache.Proxy, create_method=True)
+SharedMemoryManager.register("_ExceptionCache", callable=_ExceptionCache, proxytype=_ExceptionCache.Proxy, create_method=True)
+SharedMemoryManager.register("_getpid", callable=os.getpid, proxytype=ValueProxy)
+
+# Register shared types.
+SharedMemoryManager.register("Mutex", callable=Mutex, proxytype=Mutex.Proxy, create_method=True)
+SharedMemoryManager.register("MutexedNamespace", callable=MutexedNamespace, proxytype=MutexedNamespace.Proxy, create_method=True)
+
+
+# Register proxies.
+SharedMemoryManager.register("MutexProxy", proxytype=Mutex.Proxy, create_method=False)
+SharedMemoryManager.register("MutexedNamespaceAutoProxy", proxytype=MutexedNamespaceAutoProxy, create_method=False)
+SharedMemoryManager.register("BarrierProxy", proxytype=BarrierProxy, create_method=False)
+SharedMemoryManager.register("EventProxy", proxytype=EventProxy, create_method=False)
+
+
+# Types used for CI testing.
+SHARED_STATE_ADDRESS = ("127.0.0.1", 7000)
+SharedState = MutexedNamespaceSingleton.factory(address=SHARED_STATE_ADDRESS, name="SharedState", timeout=2)

--- a/catkit/multiprocessing.py
+++ b/catkit/multiprocessing.py
@@ -547,6 +547,11 @@ class MutexedNamespaceAutoProxy:
         assert False
 
     def __new__(cls, *args, **kwargs):
+        # NOTE: AutoProxy() returns an instance (not a type) but whose type is dynamically created at runtime. It is for
+        # this reason (and others) that all of the following lives here in ``new`` and not in a metaclass.
+        # There's also no easy way to split out AutoProxy() and multiprocess.managers.MakeProxyType().
+        # Because of this, this class allows only partial inheritance because it doesn't call ``super().__new__()`` and
+        # is incredibly hacky.
         proxy_obj = AutoProxy(*args, **kwargs)
         proxy_type = type(proxy_obj)
 

--- a/catkit/multiprocessing.py
+++ b/catkit/multiprocessing.py
@@ -29,7 +29,7 @@ class CatkitSocket(socket.socket):
         if sys.platform == 'win32':
             self.ioctl(socket.SIO_LOOPBACK_FAST_PATH, True)
 
-
+# FAIL: This pattern doesn't work as this module won't be imported by native server code on their spawned processes.
 #socket.socket = CatkitSocket
 
 

--- a/catkit/multiprocessing.py
+++ b/catkit/multiprocessing.py
@@ -8,11 +8,16 @@ import warnings
 
 # NOTE: "multiprocess" is a 3rd party package and not Python's own "multiprocessing".
 # https://github.com/uqfoundation/multiprocess is a fork of multiprocessing that uses "dill" instead of "pickle".
+import multiprocess
 import multiprocess.util as util
 from multiprocess import get_context, TimeoutError
 from multiprocess.managers import AcquirerProxy, AutoProxy, BarrierProxy, BaseProxy, DictProxy, EventProxy, \
     NamespaceProxy, Server, State, SyncManager, ValueProxy, Token, format_exc
 
+# A global auth key is needed to allow processes of separate groups to connect to one another.
+# See https://bugs.python.org/msg214582
+GLOBAL_AUTH_KEY = b"a super secure password"
+multiprocess.current_process().authkey = GLOBAL_AUTH_KEY
 
 DEFAULT_TIMEOUT = 60
 

--- a/catkit/testbed/README.md
+++ b/catkit/testbed/README.md
@@ -24,12 +24,11 @@ shared. With the original framework, this is achieved only by passing the proxie
 ``multiprocessing.Process`` when concurrent client processes are instantiated.  This requires all proxies to exist
 up-front and before any and all processes are started, thus completely limiting any dynamic object creation.
 
-In addition to this, the original framework provides for only the narrowest of critical sections of referent attribute
-access, i.e., just a single attribute access. Catkit provides some base types with mutexes exposed to the client such
-that multiple accesses can be mutexed thus allowing for arbitrarily wider critical sections. This functionality is
-essential for inter-dependent hardware control operations where the state of the testbed needs to be guaranteed not to
-have been altered by a concurrent process.
-
+In addition to this, the original framework doesn't guarantee atomic access to shared objects (only object creation is
+guaranteed to be atomic). Catkit provides some base proxies that mutex both attribute access and method calls. Such
+mutexes are also exposed to the client such that multiple accesses can be mutexed thus allowing for arbitrarily wider
+critical sections. This functionality is essential for inter-dependent hardware control operations where the state of
+the testbed needs to be guaranteed not to have been altered by a concurrent process.
 
 
 ## Core classes:

--- a/catkit/testbed/README.md
+++ b/catkit/testbed/README.md
@@ -1,0 +1,90 @@
+#  Concurrent Testbed Usage. (WIP)
+ 
+This README documents ``catkit.multiprocessing``, ``catkit.testbed.caching``, and ``catkit.testbed.experiment`` and
+their usage in developing concurrent experiments with shared access to testbed hardware.
+
+## Overview
+
+Instead of running a single sequential experiment and/or control loop on your testbed you can now run multiple
+concurrent experiments and control/loops on separate Python processes whilst still sharing all testbed hardware across
+said processes.
+
+Since pretty much all Python interpreters (e.g., CPython) don't yet support real threading (blame the GIL) this has to
+be achieved using multiprocessing by running multiple Python interpreter sessions on their own processes.
+Inter process communication is brokered using Python's shared memory managers available in``multiprocessing.managers``.
+
+The shared memory manager model works by starting shared memory servers (run on dedicated processes) in which Python
+objects can be instantiated upon and shared to multiple client processes via proxies. Such proxies then act in
+pretty much the same was as their referent instances would.
+See https://docs.python.org/3/library/multiprocessing.html#managers.
+
+The above mentioned ``catkit.multiprocessing`` module builds upon this framework extending its functionality.
+The principle addition addresses the frameworks most lacking drawback which is that shared proxies have to be just that,
+shared. With the original framework, this is achieved only by passing the proxies as ``args`` to
+``multiprocessing.Process`` when concurrent client processes are instantiated.  This requires all proxies to exist
+up-front and before any and all processes are started, thus completely limiting any dynamic object creation.
+
+In addition to this, the original framework provides for only the narrowest of critical sections of referent attribute
+access, i.e., just a single attribute access. Catkit provides some base types with mutexes exposed to the client such
+that multiple accesses can be mutexed thus allowing for arbitrarily wider critical sections. This functionality is
+essential for inter-dependent hardware control operations where the state of the testbed needs to be guaranteed not to
+have been altered by a concurrent process.
+
+
+
+## Core classes:
+
+ * ``catkit.multiprocessing.Process``: Dumps child process exceptions on a dedicated shared memory server such that they
+   can be accessed/caught by the parent (upon join).
+ * ``catkit.multiprocessing.SharedMemoryManager``: Shared memory manager.
+ * ``catkit.multiprocessing.MutexedNamespaceSingleton``: Base type for any shared object.
+ * ``catkit.multiprocessing.MutexedNamespaceAutoProxy``: Proxy type for any shared object.
+ * ``catit.testbed.caching.SharedSingletonDeviceCache``: Shared device cache.
+ * ``catkit.testbed.caching.DeviceCacheEnum``: Enum API type for shared device cache.
+ * ``catkit.testbed.experiment.SafetyTest``: Base type for all safety tests.
+ * ``catkit.testbed.experiment.Testbed``: Base type for encapsulating the entire testbed infrastructure, e.g.,
+   managing and monitoring safety tests, starting and owning all shared memory servers etc. 
+ * ``catkit.testbed.experiment.Experiment``: Base type encapsulating the experiment flow or control loop.  
+
+#### Hardware access full stack flow:
+
+The principle design feature is to remove awareness of much of the underlying infrastructure from the end user, thus
+granting them a simpler and neater task when implementing experiments and control algorithms. Such lower-level infrastructure
+includes the core infrastructure of managing device connections and lifetimes, managing shared access, safety tests, and
+most inter process communication, e.g., child exception handling etc. The only real exception to this is their need to
+understand and implement adequate critical sections where needed as per the given experiment or control loop.
+
+This abstraction is layered as the following (top down):
+
+  ``enum API`` -> ``device cache (proxy)`` -> ``device cache stored on separate server process``
+
+* Enum member attribute access: ``Device.Camera.TakeImage()`` - Device:=Enum, Camera:=member, TakeImage:=attribute. This
+  is the only layer that the user interfaces with.
+* Lookup device proxy in client side proxy cache and return if present.
+* Upon cache miss lookup device in underlying device cache proxy (hosted on shared server). Device caches exits per enum
+  member, if that member's cache hasn't yet been "activated" connect to server and instantiate the device from the
+  client. 
+* Upon miss in the device cache, instantiate device, open connection, populate underlying device cache, return proxy to
+  client, populate client side proxy cache with proxy, return proxy to caller.
+* Unwind back up the call stack.
+* Access attribute via device proxy.
+* Execute ``TakeImage`` on the remote server returning any resultant data back to client.
+
+Device connections and lifetimes are managed hierarchically as the following (bottom up):
+* Device objects are managed by their respective cache. E.g., the cache opens and closes connections.
+* Device caches are managed by their shared memory manager/servers.
+* The device servers are managed by ``catkit.testbed.experiment.Testbed``.
+
+## Implementation Details
+
+Not needing to pass proxies to ``Process`` up front can be resolved by at least two patterns:
+* Adding methods to the servers for accessing shared dicts of objects.
+* Instantiating singletons on the servers.
+
+Catkit adopts both of these patterns. For example, synchronization primitives, such as mutexes and barriers, are cached
+in dicts on a given server and can be looked up by name.  All other objects, such as the
+device/instrument objects, use the singleton pattern., one major design flaw with the above base model is that the 
+
+Lastly, the original framework requires all proxies to be created prior to starting the server and within the same
+parent process.
+

--- a/catkit/testbed/__init__.py
+++ b/catkit/testbed/__init__.py
@@ -1,2 +1,2 @@
 from catkit.testbed.caching import devices, DeviceCacheEnum, ImmutableDeviceCacheEnum
-from catkit.testbed.experiment import Experiment, SafetyException
+from catkit.testbed.experiment import Experiment, SafetyException, Testbed

--- a/catkit/testbed/caching.py
+++ b/catkit/testbed/caching.py
@@ -1,17 +1,17 @@
-from abc import abstractmethod, ABC
 from collections import namedtuple, UserDict
 from enum import Enum
-from multiprocess.managers import AcquirerProxy, DictProxy
+from functools import lru_cache
+from multiprocess.managers import AcquirerProxy, BaseProxy, DictProxy
 import warnings
 
 from catkit.interfaces.Instrument import Instrument
-from catkit.multiprocessing import DEFAULT_SHARED_MEMORY_SERVER_ADDRESS, DEFAULT_TIMEOUT, Mutex, SharedMemoryManager
+from catkit.multiprocessing import MutexedNamespace, SharedMemoryManager, MutexedNamespaceSingleton
 
 
-class UserCache(UserDict, ABC):
-    @abstractmethod
+class UserCache(UserDict):
     def load(self, key, *args, **kwargs):
-        """ Func to load non-existent cache entries. """
+        """ Func to load non-existent cache entries. Is designed to be overridden. """
+        raise KeyError(key)
 
     def __getitem__(self, key):
         item = self.data.get(key, None)
@@ -27,9 +27,6 @@ class UserCache(UserDict, ABC):
 
 class ContextCache(UserCache):
     """ Cache of context managed items (non device/instrument). """
-    def load(self, key, *args, **kwargs):
-        pass
-
     def __delitem__(self, key):
         if hasattr(self.data[key], "__exit__"):
             try:
@@ -42,107 +39,121 @@ class ContextCache(UserCache):
         self.clear()
 
 
-class MutexedCache(Mutex, UserCache):
-    """ The use of locks isn't necessary to mutex access to `self.data`, that is handled by the manager.
-        However, it is necessary if wanting to mutex multiple accesses from the caller.
-    """
+class MutexedDict(MutexedNamespace, UserCache):
+    """ Effectively MutexedDict with auto load functionality. """
 
-    def load(self, key, *args, **kwargs):
-        """ Func to load non-existent cache entries. """
-        # This is abstract for the base class but we'll make it concrete here. It ca be overridden if desired.
-        raise KeyError(key)
+    # def __init__(self, *args, lock=None, timeout=None, **kwargs):
+    #     super(MutexedDict, self).__init__(lock=lock, timeout=timeout)
+    #     super(UserCache, self).__init__(*args, **kwargs)
 
-    def __getitem__(self, item):
-        with self:
-            return super().__getitem__(item)
+    def __contains__(self, *args, **kwargs):
+        with self._catkit_mutex:
+            return super().__contains__(*args, **kwargs)
 
-    def __setitem__(self, key, value):
-        with self:
-            super().__setitem__(key, value)
+    def __delitem__(self, *args, **kwargs):
+        with self._catkit_mutex:
+            return super().__delitem__(*args, **kwargs)
 
-    def __delitem__(self, key):
-        with self:
-            super().__delitem__(key)
+    def __getitem__(self, *args, **kwargs):
+        with self._catkit_mutex:
+            return super().__getitem__(*args, **kwargs)
 
-    class Proxy(AcquirerProxy, DictProxy):
-        _exposed_ = ('__contains__', '__delitem__', '__getitem__', '__iter__', '__len__', '__setitem__', 'clear',
-                     'copy', 'get', 'has_key', 'items', 'keys', 'pop', 'popitem', 'setdefault', 'update', 'values',
-                     'acquire', 'release')
-        pass
+    def __iter__(self, *args, **kwargs):
+        with self._catkit_mutex:
+            return super().__iter__(*args, **kwargs)
+
+    def __len__(self, *args, **kwargs):
+        with self._catkit_mutex:
+            return super().__len__(*args, **kwargs)
+
+    def __setitem__(self, *args, **kwargs):
+        with self._catkit_mutex:
+            return super().__setitem__(*args, **kwargs)
+
+    def clear(self, *args, **kwargs):
+        with self._catkit_mutex:
+            return super().clear(*args, **kwargs)
+
+    def copy(self, *args, **kwargs):
+        # TODO: test this.
+        with self._catkit_mutex:
+            # Copy dict-wise
+            copy = type(self)(self.data.copy())
+            # Copy namespace-wise
+            copy.copy_from(self)
+            return copy
+
+    def get(self, *args, **kwargs):
+        with self._catkit_mutex:
+            return super().get(*args, **kwargs)
+
+    # NOTE: has_key() has been deprecated.
+    # def has_key(self, *args, **kwargs):
+    #     with self._catkit_mutex:
+    #         return super().has_key(*args, **kwargs)
+
+    def items(self, *args, **kwargs):
+        # NOTE: In the interest of thread-safety this returns a list instead of a dict view. However, also note that
+        # a race condition exists between getting this data and a subsequent dict query.
+        with self._catkit_mutex:
+            return list(super().items(*args, **kwargs))
+
+    def keys(self, *args, **kwargs):
+        # NOTE: In the interest of thread-safety this returns a list instead of a dict view. However, also note that
+        # a race condition exists between getting this data and a subsequent dict query.
+        with self._catkit_mutex:
+            return list(super().keys(*args, **kwargs))
+
+    def pop(self, *args, **kwargs):
+        with self._catkit_mutex:
+            return super().pop(*args, **kwargs)
+
+    def popitem(self, *args, **kwargs):
+        with self._catkit_mutex:
+            return super().popitem(*args, **kwargs)
+
+    def setdefault(self, *args, **kwargs):
+        with self._catkit_mutex:
+            return super().setdefault(*args, **kwargs)
+
+    def update(self, *args, **kwargs):
+        with self._catkit_mutex:
+            return super().update(*args, **kwargs)
+
+    def values(self, *args, **kwargs):
+        # NOTE: In the interest of thread-safety this returns a list instead of a dict view. However, also note that
+        # a race condition exists between getting this data and a subsequent dict query.
+        with self._catkit_mutex:
+            return list(super().values(*args, **kwargs))
+
+    class Proxy(MutexedNamespace.Proxy, DictProxy):
+        _exposed_ = (*AcquirerProxy._exposed_, *DictProxy._exposed_)
 
 
-SharedMemoryManager.register("MutexedCache", callable=MutexedCache, proxytype=MutexedCache.Proxy)
+class NestedMutexedDictProxy(MutexedDict.Proxy):
+    """ Assumes and requires all dict items to be themselves dicts. """
+    _method_to_typeid_ = {**MutexedDict.Proxy._method_to_typeid_, "__getitem__": "MutexedDictProxy"}
 
 
 # This will get nuked once all hardware adheres to the Instrument interface.
 def set_keep_alive(device, value):
     if isinstance(device, Instrument):
         device._Instrument__keep_alive = value
+        if not value:
+            device._context_counter = 0
     else:
         device._keep_alive = value
 
 
-class DeviceCache(UserCache):
+class DeviceCache(MutexedDict):
 
     Callback = namedtuple("callback", ["func", "root_key", "aliases"])
 
-    class OwnedContext:
-        """ Container to "own" cache entries such that they can't be closed by external with stmnts. """
-
-        # NOTE: A trivial container will not suffice since it will cause isinstance() checks on OwnedContext objects
-        # returned from DeviceCache to fail. Dynamic inheritance and ugly __getattribute__() switching is required.
-
-        def __new__(cls, device, *args, **kwargs):
-            class ChildOwnedContext(cls, device.__class__):
-                pass
-            return super().__new__(ChildOwnedContext, *args, **kwargs)
-
-        def __del__(self):
-            super().__getattribute__("un_own")()
-
-        def __init__(self, device):
-            object.__setattr__(self, "_owned_obj", device)
-            # Open.
-            super().__getattribute__("_owned_obj").__enter__()
-
-        def __getattribute__(self, item):
-            if item in ("__del__", "__init__", "__enter__", "__exit__", "_owned_obj", "un_own"):
-                return super().__getattribute__(item)
-            else:
-                return super().__getattribute__("_owned_obj").__getattribute__(item)
-
-        def __setattr__(self, name, value):
-            return super().__setattr__(object.__getattribute__("_owned_obj"), name, value)
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exception_type, exception_value, exception_traceback):
-            pass
-
-        def un_own(self):
-            obj = super().__getattribute__("_owned_obj")
-            if obj is None or obj.instrument is None:
-                return
-            set_keep_alive(obj, False)
-            # Close.
-            try:
-                obj.__exit__(None, None, None)
-            except Exception:
-                # Don't raise so that other devices can exit.
-                warnings.warn(f"{obj.config_id} failed to close correctly.")
-            finally:
-                pass
-                # object.__setattr__(self, "__owned_obj", None)
-            return obj
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.aliases = {}
-        self.callbacks = {}
+    aliases = {}
+    callbacks = {}
 
     def __enter__(self):
-        self.clear()
+        self.clear()  # This may not be desirable to all users.
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -151,13 +162,45 @@ class DeviceCache(UserCache):
     def __del__(self):
         self.clear()
 
+    def get(self, key, *args, **kwargs):
+        key = key.name if isinstance(key, DeviceCacheEnum) else key
+        return super().get(key, *args, **kwargs)
+
+    def pop(self, key, *args, **kwargs):
+        key = key.name if isinstance(key, DeviceCacheEnum) else key
+        return super().pop(key, *args, **kwargs)
+
     def __delitem__(self, key):
-        self.data[key].un_own()
-        del self.data[key]
+        key = key.name if isinstance(key, DeviceCacheEnum) else key
+
+        # Deleting the device won't close it if external references exist, this must be done explicitly.
+        obj = self[key]
+        set_keep_alive(obj, False)
+
+        # Explicitly reset context counter to force closure.
+        if hasattr(obj, "_context_counter"):
+            obj._context_counter = 0
+
+        # Close.
+        try:
+            obj.__exit__(None, None, None)
+        except Exception:
+            raise
+            # Don't raise so that other devices can exit.
+            warnings.warn(f"{obj.config_id} failed to close correctly.")
+        finally:
+            pass
+
+        super().__delitem__(key)
+
+    def __contains__(self, item):
+        item = item.name if isinstance(item, DeviceCacheEnum) else item
+        return super().__contains__(item)
 
     def __getitem__(self, item):
+        item = item.name if isinstance(item, DeviceCacheEnum) else item
         try:
-            return self.data[item]
+            return super().__getitem__(item)
         except KeyError:
             # Try aliases.
             ret = self.aliases.get(item)
@@ -168,33 +211,35 @@ class DeviceCache(UserCache):
                 # root_keys (to simplify closures). In which case, aliases need to be checked and the simplest way to do
                 # this is to call __getitem__() (again).
                 # Infinite recursion shouldn't occur as load() should correctly populate self.data[item].
-                return self.__getitem__(item)
+                return self[item]
             else:
                 return ret
 
     def __setitem__(self, key, value):
+        key = key.name if isinstance(key, DeviceCacheEnum) else key
+
         def raise_on_collision(obj_a, obj_b):
             nonlocal key
             # Raise on collision but only if they're NOT the same underlying object.
-            obj_a = obj_a._owned_obj if isinstance(obj_a, self.OwnedContext) else obj_a
-            obj_b = obj_b._owned_obj if isinstance(obj_b, self.OwnedContext) else obj_b
-
             if obj_a is not obj_b:
                 raise KeyError(f"Cache collision: '{key}' key already exists in device cache.")
 
         if key in self.data:
-            raise_on_collision(self.data[key], value)
+            raise_on_collision(super().__getitem__(key), value)
         elif key in self.aliases:
             raise_on_collision(self.aliases[key], value)
         else:
-            self.data[key] = self.OwnedContext(value)
+            super().__setitem__(key, value)
+            self[key].__enter__()
+            assert self[key].is_open()
 
     def open_all(self):
         if not self.callbacks:
             return
 
         for callback in self.callbacks.values():
-            self.__getitem__(callback.root_key)
+            #self.__getitem__(callback.root_key)
+            self[callback.root_key]
         return self
 
     def load(self, key, *args, **kwargs):
@@ -208,7 +253,10 @@ class DeviceCache(UserCache):
         callback = self.callbacks.get(key)
 
         # Instantiate, open, and own it.
+        # NOTE: The device is opened in self.__setitem__
         self.update({key: callback.func()})
+        assert key in self
+
         # Register aliases.
         aliases = callback.aliases
         if aliases:
@@ -216,22 +264,31 @@ class DeviceCache(UserCache):
                 # Check for collisions.
                 if alias in self.aliases:
                     raise KeyError(f"Cache collision: '{alias}' key already exists in device cache.")
-                self.aliases[alias] = self.data[key]
+                self.aliases[alias] = super().__getitem__(key)
 
     def link(self, key, aliases=None):
         """ Decorator for testbed device funcs to automatically cache them. """
+
+        key = key.name if isinstance(key, DeviceCacheEnum) else key
+
         def decorator(func):
             def wrapper(*args, **kwargs):
+                nonlocal self
                 # Return cached instances if present.
                 try:
-                    return self.data[key]  # Only possible if a previous cache access occurred.
+                    if key in self:  # __contains__ doesn't call __getitem__ so won't auto load on miss.
+                        return self[key]
+                    #return self.data[key]  # Only possible if a previous cache access occurred.
                 except (KeyError, NameError):  # Do this to help experiment.RestrictedDeviceCache when locked.
                     pass
+
                 # Call func.
                 ret = func(*args, **kwargs)
+
                 # Don't automatically cache, if the user wants it cached they need to access via the cache itself.
                 #self.update({key: ret})
                 return ret
+
             # Register callback to be called upon a cache miss. Register func and not wrapper to avoid future pretzeling.
             self.callbacks[key] = self.Callback(func=func, root_key=key, aliases=aliases)
             if aliases:
@@ -252,34 +309,243 @@ class DeviceCache(UserCache):
         return super().clear()
 
 
+class SharedSingletonDeviceCache(MutexedNamespaceSingleton, DeviceCache):
+    instance = None
+
+    @classmethod
+    def factory(cls, address=None, name=None, timeout=None):
+        # NOTE: This has limited use with a spawned context due to bug when pickling abstract derived types,
+        # such as this one (via UserDict).
+        return super().factory(address=address, name=name, timeout=timeout, new_class_dict=dict(callbacks={},
+                                                                                                aliases={}))
+
+    @classmethod
+    def link(cls, key, aliases=None):
+        """ Decorator for testbed device funcs to automatically cache them. """
+
+        key = key.name if isinstance(key, DeviceCacheEnum) else key
+
+        def decorator(func):
+            # Register callback to be called upon a cache miss. Register func and not wrapper to avoid future pretzeling.
+            cls.callbacks[key] = cls.Callback(func=func, root_key=key, aliases=aliases)
+            if aliases:
+                for alias in aliases:
+                    # Check for collisions.
+                    if alias in cls.callbacks:
+                        raise KeyError(f"Cache collision: '{alias}' key already exists in device cache.")
+                    cls.callbacks[alias] = cls.Callback(func=func, root_key=key, aliases=None)
+
+            def wrapper(*args, **kwargs):
+                nonlocal cls
+                # Return cached instances if present.
+                if key in cls():
+                    return cls()[key]
+
+                # Call func.
+                ret = func(*args, **kwargs)
+
+                # Don't automatically cache, if the user wants it cached they need to access via the cache itself.
+                #self.update({key: ret})
+                return ret
+            return wrapper
+        return decorator
+
+    class Proxy(MutexedNamespaceSingleton.Proxy, DictProxy):
+        # Have items (devices) returned from the remote server be proxies such that their attributes & methods
+        # will be updated and called on the server.
+        # The proxy type is that of catkit.interfaces.Instrument.Instrument.Proxy which is registered with the manager
+        # in its module as the str "InstrumentAutoProxy".
+        _method_to_typeid_ = {"__getitem__": "InstrumentProxy",
+                              "get": "InstrumentProxy",
+                              "pop": "InstrumentProxy",
+                              "popitem": "InstrumentProxy",
+                              **MutexedNamespaceSingleton.Proxy._method_to_typeid_,
+                              **DictProxy._method_to_typeid_}
+        _exposed_ = (*MutexedNamespaceSingleton.Proxy._exposed_, *DictProxy._exposed_)
+
+        #@lru_cache(maxsize=None)
+        def __getitem__(self, item):
+            # We don't want to send the enum member as it contains a ref to the cache
+            item = item.name if isinstance(item, DeviceCacheEnum) else item
+            return super().__getitem__(item)
+
+        def __setitem__(self, item, value):
+            # We don't want to send the enum member as it contains a ref to the cache
+            item = item.name if isinstance(item, DeviceCacheEnum) else item
+            return super().__setitem__(item, value)
+
+        def __delitem__(self, item):
+            # We don't want to send the enum member as it contains a ref to the cache
+            item = item.name if isinstance(item, DeviceCacheEnum) else item
+            return super().__delitem__(item)
+
+        def values(self):
+            """ DictProxy returns a list instead of a view, as does this. """
+            lst = []
+            for key in self:
+                lst.append(self[key])
+            return lst
+
+        def items(self):
+            """ DictProxy returns a list instead of a view, as does this. """
+            values = self.values()
+            keys = self.keys()
+            return list(zip(keys, values))
+
+
 class DeviceCacheEnum(Enum):
     """ Enum API to DeviceCache. """
 
-    def __init__(self, description, config_id):
+    def __init__(self, description, config_id, cache=None):
         self.description = description
         self.config_id = config_id
+
+        # Use the default cache identifier if None.
+        self.cache = self.default_cache() if cache is None else cache
+        self.cache_type = self.cache if isinstance(self.cache, type) else type(self.cache)
+
+        # Local cache for caching proxies when using shared memory.
+        self.using_shared_memory = False#isinstance(self.cache_type, SharedSingletonDeviceCache)
+        self.local_proxy_cache = {} if self.using_shared_memory else None
+
+        # Needs to be last entry to this code block.
+        # It prevents __getattr__ and __setattr__ pointing through to the cache prior to this line.
         self.__object_exists = True
+
+    def link(self, aliases=None):
+        return getattr(self, "cache").link(key=getattr(self, "name"), aliases=aliases)
+
+    @classmethod
+    def open_all(cls):
+        for device in cls:
+            assert device().is_open()
+
+    @staticmethod
+    def default_cache():
+        """ Can be overridden.
+            This provides an easy way to specify the default cache without needing to do so explicitly for each member
+        """
+        global devices
+        return devices
+
+    def get_device(self, name):
+        object.__getattribute__(self, "activate_cache")()
+        cache = object.__getattribute__(self, "cache")
+        if self.using_shared_memory:
+            # NOTE: It's possible that the proxy has been removed from the remote cache.
+            device = self.local_proxy_cache.get(name, None)
+            if not device:
+                device = cache[name]
+                self.local_proxy_cache[name] = device
+        else:
+            device = cache[name]
+        return device
 
     @classmethod
     def _missing_(cls, value):
         """ Allow lookup by config_id, such that DeviceCacheEnum(config_id) returns its matching member. """
+        if isinstance(value, DeviceCacheEnum):
+            value = value.config_id
+
         for item in cls:
             if value in (item.config_id, item.description):
+                # TODO: should really test cache equivalence.
                 return item
 
+    # def __getstate__(self):
+    #     """ Remove cache proxy before pickling. """
+    #     if not isinstance(self.cache, BaseProxy):
+    #         return self
+    #
+    #     import copy
+    #     obj = copy.copy(self)  # Shallow copy.
+    #     obj.cache = obj.cache_type
+    #     return obj
+
+    def __call__(self):
+        return self.get_device(object.__getattribute__(self, "name"))
+
+    def is_open(self):
+        cache = object.__getattribute__(self, "cache")
+        if cache is None or isinstance(cache, type):
+            return False
+
+        if self.name in self.cache:
+            return self.cache[self.name].is_open() is not None
+        else:
+            return False
+
+    # Override base Instrument context to manage mutex rather than device open & close.
+    def __enter__(self):
+        """ DeviceCacheEnum.member.cache[member].acquire() """
+        return self.__getattr__("acquire")()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """ DeviceCacheEnum.member.cache[member].release() """
+        return self.__getattr__("release")()
+
+    # Since Python doesn't allow for function overloading, we can only have one set of context managers and mutex funcs.
+    # These can either be classmethods or an instance methods
+    # I.e., member.cache.acquire() or member.cache[member].acquire.
+
+    # Using with stmnts per instrument, rather than per enum class, would require the user to write far less boiler
+    # plate code than the alternative (as implemented above).
+    # However, for example, if acquire() and release() are classmethods of the enum, __getattribute__() will never call
+    # __getattr__ and thus enum.member.acquire() := enum.acquire() as enum.member.acquire() won't poke through to call
+    # Instrument.Proxy.acquire(). This equivalence would be grossly misleading and thus prevents us from having a
+    # classmethod of this nature at all, as enum.member.acquire() would act on the entire class (see below commented out
+    # implementation.
+
+    # @classmethod
+    # def acquire(cls, *args, **kwargs):
+    #     all_locked = True
+    #     for member in cls:
+    #         all_locked &= member.cache.acquire(*args, **kwargs)
+    #     return all_locked
+    #
+    # @classmethod
+    # def release(cls):
+    #     for member in cls:
+    #         member.cache.release()
+
+    def activate_cache(self, *args, **kwargs):
+        cache = object.__getattribute__(self, "cache")
+        if cache is None or isinstance(cache, type):
+            cache_type = object.__getattribute__(self, "cache_type")
+            object.__setattr__(self, "cache",  cache_type(*args, **kwargs))
+
+    @classmethod
+    def reset(cls):
+        for member in cls:
+            object.__setattr__(member, "cache", None)
+            local_proxy_cache = object.__getattribute__(member, "local_proxy_cache")
+            if local_proxy_cache:
+                local_proxy_cache.clear()
+
+    # NOTES on __getattr__ & __setattr__:
+    # The functionality of poking through the enum to the cache needs to be delayed beyond enum creation such that the
+    # server can be started and other flags (making shared memory usage optional) can be correctly set. This is achieved
+    # using two patterns.
+    # 1) __getattr__: (noting that this is only called if the attribute doesn't already exist) any protected attr
+    #    (those with a leading "_") belong to the enum, otherwise it pokes through to the cache.
+    # 2) __setattr__: The same is true as is for __getattr__ however, this logic is deferred until __ini__ returns. This
+    #    is so the desired member values can be set.
+    # The caveat with the underscore pattern is that it is that also used by multiprocess.managers.BaseProxy and
+    # therefore proxy attrs (not referent attrs) won't be accessible via the enum API, e.g., Device.CAMERA._getvalue().
+    # Instead, the actual proxy would first have to be retrieved, e.g., Device.CAMERA()._getvalue().
+
     def __getattr__(self, item):
-        global devices
-        """ Allow DeviceCacheEnum.member.attribute -> catkit.testbed.devices[member].attribute """
-        config_id = object.__getattribute__(self, "config_id")
-        member = self.__class__(config_id)
-        device = devices[member]
-        return device.__getattribute__(item)
+        """ Allow DeviceCacheEnum.member.attribute -> DeviceCacheEnum.member.cache[member].attribute """
+        if item[0] == "_":
+            return object.__getattribute__(self, item)
+        else:
+            device = self.get_device(object.__getattribute__(self, "name"))
+            return getattr(device, item)
 
     def __setattr__(self, name, value):
-        if "_DeviceCacheEnum__object_exists" in self.__dict__:
-            config_id = object.__getattribute__(self, "config_id")
-            member = self.__class__(config_id)
-            device = devices[member]
+        """ Allow DeviceCacheEnum.member.attribute = value -> DeviceCacheEnum.member.cache[member].attribute = value """
+        if object.__getattribute__(self, "__dict__").get("_DeviceCacheEnum__object_exists", None) and name[0] != "_":
+            device = self.get_device(self.name)
             device.__setattr__(name, value)
         else:
             object.__setattr__(self, name, value)
@@ -296,20 +562,21 @@ class RestrictedDeviceCache(DeviceCache):
     """ Restricted version of catkit.testbed.caching.DeviceCache that allows linking but nothing else until unlocked. """
 
     def __init__(self, *args, **kwargs):
-        super().__setattr__("__lock", False)  # Unlock such that super().__init__() has access.
+        object.__setattr__(self, "__lock", False)  # Unlock such that super().__init__() has access.
         super().__init__(*args, **kwargs)
-        super().__setattr__("__lock", True)
-        super().__setattr__("__unrestricted", ("aliases", "Callback", "callbacks", "link"))
+        object.__setattr__(self, "__lock", True)
+        object.__setattr__(self, "__unrestricted", ("aliases", "Callback", "callbacks", "link", "__name__", "__class__",
+                                               "_catkit_mutex"))
 
     def __getattribute__(self, item):
-        if (super().__getattribute__("__lock") and
-                item not in super().__getattribute__("__unrestricted")):
+        if (object.__getattribute__(self, "__lock") and
+                item not in object.__getattribute__(self, "__unrestricted")):
             raise NameError(f"Access to '{item}' is restricted The device cache can only be used from a running experiment.")
         return super().__getattribute__(item)
 
     def __setattr__(self, item, value):
-        if (super().__getattribute__("__lock") and
-                item not in super().__getattribute__("__unrestricted")):
+        if (object.__getattribute__(self, "__lock") and
+                item not in object.__getattribute__(self, "__unrestricted")):
             raise NameError(f"Access to '{item}' is restricted! The device cache can only be used from a running experiment.")
         return super().__setattr__(item, value)
 
@@ -326,60 +593,13 @@ class RestrictedDeviceCache(DeviceCache):
         self.clear()
 
 
-class SharedState:
-    """ Container for SharedMemoryManager and (default) SharedMemoryManager().SharedState().
-
-    Parameters
-    ----------
-    address : tuple
-        A tuple of the following `(IP, port)` to start the shared server on.
-    timeout : float, int
-        Default timeout for mutexing access.
-    own : bool
-        True: Use from parent to "own" and thus start the server. Will also shutdown when deleted.
-        False: (default) Use from clients to connect to an already started server.
-    """
-
-    def __init__(self, *args, address=DEFAULT_SHARED_MEMORY_SERVER_ADDRESS,
-                 timeout=DEFAULT_TIMEOUT,
-                 own=False,
-                 namespace="SharedState",
-                 **kwargs):
-        super().__init__(*args, **kwargs)
-        self._own = own  # Whether to start and thus later shutdown, or just connect to ab existing server.
-        self._manager = None  # The shared memory manager.
-        self._shared_state = None
-
-        self._manager = SharedMemoryManager(address=address, own=own)  # Instantiate the shared memory manager.
-        # Either start it or just connect to an existing one.
-        if self._own:
-            self._manager.start()  # Shutdown in __del__().
-        else:
-            self._manager.connect()
-
-        self._shared_state = getattr(self._manager, namespace)(timeout=timeout)
-
-    def __enter__(self):
-        return self._shared_state.__enter__()
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        return self._shared_state.__exit__(exc_type, exc_val, exc_tb)
-
-    def __getattr__(self, name):
-        if name[0] == '_':
-            return object.__getattribute__(self, name)
-        return self._shared_state.__getattr__(name)
-
-    def __setattr__(self, name, value):
-        if name[0] == '_':
-            return object.__setattr__(self, name, value)
-        return self._shared_state.__setattr__(name, value)
-
-    def __del__(self):
-        if self._own:
-            self._manager.shutdown()
-
-
 # Restrict the device cache such that only linking is allowed. Once run_experiment() is called this gets swapped
 # out for the unrestricted version that is context manged by Experiment.
 devices = RestrictedDeviceCache()
+
+# Register shared types.
+SharedMemoryManager.register("MutexedDict", callable=MutexedDict, proxytype=MutexedDict.Proxy, create_method=True)
+
+# Register proxies.
+SharedMemoryManager.register("MutexedDictProxy", proxytype=MutexedDict.Proxy, create_method=False)
+SharedMemoryManager.register("NestedMutexedDictProxy", proxytype=NestedMutexedDictProxy, create_method=False)

--- a/catkit/testbed/caching.py
+++ b/catkit/testbed/caching.py
@@ -172,18 +172,11 @@ class DeviceCache(MutexedDict):
 
     def __delitem__(self, key):
         key = key.name if isinstance(key, DeviceCacheEnum) else key
+        obj = self[key]
 
         # Deleting the device won't close it if external references exist, this must be done explicitly.
-        obj = self[key]
-        set_keep_alive(obj, False)
-
-        # Explicitly reset context counter to force closure.
-        if hasattr(obj, "_context_counter"):
-            obj._context_counter = 0
-
-        # Close.
         try:
-            obj.__exit__(None, None, None)
+            object.__getattribute__(obj, "_forced_safe_close")()
         except Exception:
             raise
             # Don't raise so that other devices can exit.

--- a/catkit/testbed/caching.py
+++ b/catkit/testbed/caching.py
@@ -1,7 +1,7 @@
 from collections import namedtuple, UserDict
 from enum import Enum
 from functools import lru_cache
-from multiprocess.managers import AcquirerProxy, BaseProxy, DictProxy
+from multiprocess.managers import AcquirerProxy, DictProxy
 import warnings
 
 from catkit.interfaces.Instrument import Instrument
@@ -402,9 +402,6 @@ class DeviceCacheEnum(Enum):
         # Use the default cache identifier if None.
         self.cache = self.default_cache() if cache is None else cache
         self.cache_type = self.cache if isinstance(self.cache, type) else type(self.cache)
-
-        # Local cache for caching proxies when using shared memory.
-        self.using_shared_memory = False#isinstance(self.cache_type, SharedSingletonDeviceCache)
 
         # Needs to be last entry to this code block.
         # It prevents __getattr__ and __setattr__ pointing through to the cache prior to this line.

--- a/catkit/testbed/caching.py
+++ b/catkit/testbed/caching.py
@@ -507,6 +507,8 @@ class DeviceCacheEnum(Enum):
 
     @classmethod
     def reset(cls):
+        cls.get_device.cache_clear()
+        cls._missing_.cache_clear()
         for member in cls:
             object.__setattr__(member, "cache", None)
 

--- a/catkit/testbed/experiment.py
+++ b/catkit/testbed/experiment.py
@@ -54,6 +54,9 @@ class SafetyTest(ABC):
 
 class Testbed:
     """ Class for owning testbed infrastructure such as any shared memory servers and running safety checks. """
+    
+    # NOTE: The following event isn't implicitly used nor waited upon, it's hosted here such that it can be imported.
+    STOP_EVENT = "stop the testbed running"
 
     def __init__(self, safety_tests, output_path=None, suffix=None,
                  safety_check_interval=60):

--- a/catkit/testbed/experiment.py
+++ b/catkit/testbed/experiment.py
@@ -1,50 +1,69 @@
 from abc import ABC, abstractmethod
 import logging
-import time
+import os
+import _thread
+import threading
+import uuid
 
-import catkit.util
-from catkit.testbed import devices
 from catkit import datalogging
-from catkit.multiprocessing import Process
+from catkit.multiprocessing import DEFAULT_TIMEOUT, EXCEPTION_SERVER_ADDRESS, Process, SharedMemoryManager
 
 
-class SafetyTest(ABC):
-    name = None
-    warning = False
-
-    @abstractmethod
-    def check(self):
-        """Implement to return two values: boolean for pass/fail, and a string for status message."""
+STOP_EVENT = "hicat_stop_event"
+SAFETY_EVENT = "hicat_safety_event"
+SAFETY_BARRIER = "hicat_safety_barrier"
 
 
 class SafetyException(Exception):
-    def __init__(self, *args):
-        Exception.__init__(self, *args)
+    pass
 
 
-class Experiment(ABC):
-    """
-    Abstract base class that instills safety monitoring into any class that inherits it.  Subclasses
-    need to implement a function called "experiment()", which is designated as an abstractmethod here.
-    """
-    name = None
+class StopException(Exception):
+    pass
 
-    log = logging.getLogger(__name__)
-    data_log = datalogging.get_logger(__name__)
 
-    def __del__(self):
-        self.clear_cache()
+class SafetyTest(ABC):
+    def __init__(self, *args, max_consecutive_failures=0, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name = None
+        self.log = logging.getLogger()
 
-    def __init__(self, safety_tests, safety_check_interval=60, output_path=None, suffix=None):
-        """ Initialize attributes common to all Experiments.
-        All child classes should implement their own __init__ and call this via super()
+        # Permit <max_consecutive_failures> consecutive failures before failing test and raising.
+        self.max_consecutive_failures = max_consecutive_failures
+        self.consecutive_failure_counter = 0
 
+    def do_check(self, force_raise=False):
+        try:
+            self.check()
+        except Exception as error:
+            if force_raise:
+                raise
+
+            self.consecutive_failure_counter += 1
+            if self.consecutive_failure_counter > self.max_consecutive_failures:
+                raise
+            else:
+                self.log.warning(f"Safety test warning issued for {self.name}: {error}")
+        else:
+            self.consecutive_failure_counter = 0
+
+    @abstractmethod
+    def check(self):
+        """Implement to conduct safety check and raise a SafetyException upon failure. """
+
+
+class Testbed:
+    """ Class for owning testbed infrastructure such as any shared memory servers and running safety checks. """
+
+    def __init__(self, safety_tests, output_path=None, suffix=None,
+                 safety_check_interval=60):
+        """
         Parameters
         ----------
         safety_tests : list
             List of SafetyTest class defs, not already instantiated objects (nothing else should own these).
         safety_check_interval : int, float, optional:
-            Time interval between calling each SafetyTest.chceck().
+            Time interval between calling check_safety().
         output_path: str, optional
             Output directory to write all files to (or to subdirectories thereof).
              For the vast majority of use cases this should be left as None, in which
@@ -52,189 +71,332 @@ class Experiment(ABC):
         suffix : str, optional
             Descriptive string to include as part of the path.
         """
-        # Default is to wait to set the path until the experiment starts (rather than the constructor)
-        # but users can optionally pass in a specific path if they want to do something different in a
-        # particular case.
+        self.log = None
         self.output_path = output_path
         self.suffix = suffix
+        self.init_path()
+        self.init_log()
+
+        self.safety_check_interval = safety_check_interval
+
+        self.exception_manager = SharedMemoryManager(address=EXCEPTION_SERVER_ADDRESS, own=True)
+        self.stop_event = None
+        self.safety_event = None
+        self.barrier = None
+
+        self.safety_process = None
+        self.safety_tests = []
+
+        for test in safety_tests:
+            self.safety_tests.append(test())
+
+    def __enter__(self):
+        try:
+            self._setup()
+
+            assert self.stop_event is not None
+            assert self.safety_event is not None
+
+            # Run an initial test before starting continuous monitoring.
+            # NOTE: These initial tests will always raise upon failure, irrespective of a test's max_consecutive_failures.
+            self.check_safety(force_raise=True)
+
+            # Start continuous monitoring.
+            self.safety_process = Process(target=self.safety_monitor, name="Safety Test Monitor", args=(self.barrier,))
+            self.safety_process.start()  # NOTE: This will need to be joined.
+            # print(f" ### Safety tests monitored on PID: {self.safety_process.pid}")
+            self.log.info(f"Continuously monitoring safety tests... (on PID: {self.safety_process.pid})")
+
+            # Don't return until continuous monitoring has started.
+            self.barrier.wait()
+
+            return self
+        except Exception:
+            try:
+                try:
+                    self.log.exception("The testbed encountered the following error(s):")
+                finally:
+                    # NOTE: __exit__() is not called if this func raises.
+                    self._teardown()
+            finally:
+                raise
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        try:
+            self._teardown()
+        finally:
+            if exc_type:
+                self.log.exception("The testbed encountered the following error(s):")
+
+    def _setup(self):
+        """ Setup the necessary exception manager server and run safety check monitor.
+            Override this to start and context manage any and all other servers.
+        """
+        # Start server to catch and manage exceptions from parallel processes.
+        self.exception_manager.start()  # NOTE: This is joined in self._teardown().
+        self.stop_event = self.exception_manager.get_event(STOP_EVENT)
+        self.safety_event = self.exception_manager.get_event(SAFETY_EVENT)
+        self.barrier = self.exception_manager.get_barrier(SAFETY_BARRIER, parties=2)
+
+    def check_safety(self, *args, **kwargs):
+        self.log.info("Running safety tests...")
+        for safety_test in self.safety_tests:
+            try:
+                safety_test.do_check(*args, **kwargs)
+            except Exception:
+                # NOTE: This order is critical such that self.safety_event is set before self.stop_event.wait() wakes.
+                self.safety_event.set()
+                self.stop_event.set()
+                raise
+
+        self.log.info("All Safety tests passed!")
+
+    def safety_monitor(self, barrier):
+        """ Monitor all safety checks.
+            NOTE: This is run on a child process.
+        """
+        self.init_log()
+
+        barrier.wait()
+
+        while not self.stop_event.is_set():
+            # NOTE: Upon failure, self.check_safety(), sets both self.safety_event and self.stop_event, and raises a
+            # SafetyException (in that order).
+            self.check_safety()
+            self.stop_event.wait(self.safety_check_interval)
+
+    def _teardown(self):
+        """ Override this to stop/join/shutdown any and all other servers started by setup(). """
+        try:
+            try:
+                try:
+                    if self.log:
+                        self.log.info(" Cleaning up (teardown)...")
+                finally:
+                    # Stop the safety monitor process so that it can be joined.
+                    # NOTE: This will also stop EVERYTHING else - no safety := no experiment.
+                    if self.stop_event:
+                        self.stop_event.set()
+            finally:
+                if self.safety_process:
+                    self.safety_process.join(DEFAULT_TIMEOUT)
+        finally:
+            # Shutdown the exception handler manager.
+            # NOTE: self.stop_event and self.safety_event are local to the exception manager server process and
+            # will not be accessible post shutdown.
+            if self.exception_manager is not None:
+                self.exception_manager.shutdown()
+
+    def init_path(self):
+        """ Set up output. """
+        pass
+
+    def init_log(self):
+        """ Initialize log writing.
+            Override to setup log handlers etc.
+        """
+        self.log = logging.getLogger()
+
+
+class Experiment:
+    """
+    Base class that instills safety monitoring into any class that inherits it.  Subclasses
+    need to implement a function called "experiment()".
+    """
+    name = "Base Experiment"
+
+    log = logging.getLogger()
+    data_log = datalogging.get_logger(__name__)
+
+    def __init__(self, output_path=None, suffix=None, stop_all_on_exception=True, run_forever=False,
+                 disable_shared_memory=False):
+        """ Initialize attributes common to all Experiments.
+        All child classes should implement their own __init__ and call this via super()
+
+        Parameters
+        ----------
+        output_path: str, optional
+            Output directory to write all files to (or to subdirectories thereof).
+             For the vast majority of use cases this should be left as None, in which
+             case it will be auto-generated based on date-time + suffix.
+        suffix : str, optional
+            Descriptive string to include as part of the path.
+        run_forever : bool, optional
+            Allows the experiment to continue running even when concurrent experiments have set the global stop event.
+            It will, however, stop for a safety event.
+        stop_all_on_exception : bool, optional
+            Allows peripheral concurrent experiments to run and fail, for example, from syntax errors without stopping
+            all other experiments.
+        disable_shared_memory : bool, optional
+            Disable shared memory. When True some peripheral shared memory will still exist and the main
+            experiment will run on the parent process. When False, the main experiment is run on a child process.
+        """
+        self.output_path = output_path
+        self.suffix = suffix
+        self.stop_all_on_exception = stop_all_on_exception
+        self.run_forever = run_forever
+        self.disable_shared_memory = disable_shared_memory
+
+        self.exception_manager = SharedMemoryManager(address=EXCEPTION_SERVER_ADDRESS, own=False)
+        self.experiment_process = None
+        self.stop_event = None
+        self.safety_event = None
+        self._event_monitor_barrier = None
+        self._kill_event_monitor_event = None
 
         self.pre_experiment_return = None
         self.experiment_return = None
         self.post_experiment_return = None
 
-        self.safety_check_interval = safety_check_interval
-        self.safety_tests = []
-        for test in safety_tests:
-            self.safety_tests.append(test())
+        self.init_path()
+        self.init_log()
 
-    def pre_experiment(self, *args, **kwargs):
-        """ This is called immediately BEFORE self.experiment()."""
-        pass
-
-    @abstractmethod
-    def experiment(self, *args, **kwargs):
-        """ This is where the experiment gets implemented. All child classes must implement this. """
-
-    def post_experiment(self, *args, **kwargs):
-        """ This is called immediately AFTER self.experiment()."""
-        pass
+    def join(self, *args, **kwargs):
+        if self.experiment_process:
+            self.experiment_process.join(*args, **kwargs)
 
     def start(self):
+        """ Start the experiment on a separate process and then returns (is non-blocking, it does not wait).
+            It works like multiprocessing.Process.start(), a join() is thus required.
         """
-        This function starts the experiment on a separate process and monitors power and humidity while active.
-        Do not override.
-        """
-        experiment_process = None
+        # Check that we can connect from the parent process.
+        self.exception_manager.connect()  # Needs to have already been started.
+        self.stop_event = self.exception_manager.get_event(STOP_EVENT)
+        self.safety_event = self.exception_manager.get_event(SAFETY_EVENT)
+
         try:
-
-            self.log.info("Running safety tests...")
-            # Check tests before starting experiment.
-            for safety_test in self.safety_tests:
-                status, msg = safety_test.check()
-                # msg may have a newline in it; if so split that into separate log messages
-                for msg_line in msg.split("\n"):
-                    self.log.info(msg_line)
-                if not status:
-                    errmessage = safety_test.name + " reports unsafe conditions. Aborting experiment before start... Details: {}".format(msg)
-                    print(errmessage)
-                    self.log.critical(errmessage)
-                    raise SafetyException(errmessage)
-            self.log.info("Safety tests passed!")
-
-            # Initialize experiment output path. Do this here so the output path is available in the parent process
-            self.init_experiment_path()
-
-            self.log.info("Creating separate process to run experiment...")
-            # Spin off and start the process to run the experiment.
-            experiment_process = Process(target=self.run_experiment, name=self.name)
-            experiment_process.start()
-            self.log.info(self.name + " process started")
-
-            while experiment_process.is_alive():
-
-                for safety_test in self.safety_tests:
-                    status, message = safety_test.check()
-                    if status:
-                        # Check passed, clear any warning that might be set and proceed to sleep until next iteration.
-                        for msg_line in message.split("\n"):
-                            self.log.info(msg_line)
-                        safety_test.warning = False
-
-                    elif safety_test.warning:
-                            # Shut down the experiment (but allow context managers to exit properly).
-                            errmessage = safety_test.name + " reports unsafe conditions repeatedly. Aborting experiment! Details: {}".format(msg)
-                            self.log.critical(errmessage)
-                            catkit.util.soft_kill(experiment_process)
-                            raise SafetyException(errmessage)
-
-                    else:
-                        errmessage = (message + "\n" +  "Warning issued for " + safety_test.name +
-                              ". Experiment will be softly killed if safety check fails again.")
-                        self.log.warning(errmessage)
-                        safety_test.warning = True
-
-                # Sleep until it is time to check safety again.
-                if not self.__smart_sleep(self.safety_check_interval, experiment_process):
-                    # Experiment ended before the next check interval, exit the while loop.
-                    break
-                    self.log.info("Experment ended before check interval; exiting.")
-        except KeyboardInterrupt:
-            self.log.exception("Parent process: caught ctrl-c, raising exception.")
+            if self.disable_shared_memory:
+                self.log.info(f"Running experiment on parent process (PID: {os.getpid()})...")
+                self.run_experiment()
+            else:
+                # Start the process to run the experiment.
+                self.log.info("Creating separate process to run experiment...")
+                self.experiment_process = Process(target=self.run_experiment, name=self.name)
+                self.experiment_process.start()
+                # print(f" ### Child experiment process on PID: {self.experiment_process.pid}")
+                self.log.info(f"{self.name} process started on PID: {self.experiment_process.pid}")
+        except Exception:
+            if self.stop_all_on_exception:
+                self.stop_event.set()
             raise
-        except SafetyException:
-            self.log.exception("Safety exception.")
-            raise
-        except Exception as e:
-            safety_exception = SafetyException("Monitoring process caught an unexpected problem: ", e)
-            self.log.exception(safety_exception)
-            # Shut down the experiment (but allow context managers to exit properly).
-            if experiment_process is not None and experiment_process.is_alive():
-                catkit.util.soft_kill(experiment_process)
-            # must return SafetyException type specifically to signal queue to stop in typical calling scripts
-            raise safety_exception
 
-        # Explicitly join even though experiment_process.is_alive() will call join() if it's no longer alive.
-        experiment_process.join()  # This will raise any child exceptions.
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.join()
+
+    def event_monitor(self):
+        """ This is run on a thread on the child process running self.experiment(). It monitors events and then raises
+            to stop parent thread running self.experiment().
+            NOTE: It doesn't explicitly stop the parent process, it will implicitly stop the parent process if it's
+            waiting in a join() (which it needs to be).
+        """
+
+        try:  # This must always be running, so stop main thread upon exception.
+            self._event_monitor_barrier.wait()  # Used to sync with the main thread so that it doesn't proceed without being monitored.
+
+            # Wait indefinitely (this is run on a daemonic thread).
+            if self.run_forever:
+                # Ignore stop_event but DON'T ignore safety_event.
+                self.safety_event.wait()
+            else:
+                # NOTE: self.stop_event is set upon a safety check failure as well as self.safety_event, so waiting on
+                # self.stop_event is effectively waiting on self.safety_event also.
+                self.stop_event.wait()
+        finally:
+            # NOTE: This event monitor can be killed WITHOUT raising SIGINT (as it does below) by setting
+            # self._kill_event_monitor_event BEFORE setting self.stop_event.
+            if self._kill_event_monitor_event.is_set():
+                return
+            # Interrupt the main thread with a KeyboardInterrupt exception.
+            # NOTE: This won't interrupt time.sleep(). See https://docs.python.org/3/library/time.html#time.sleep
+            _thread.interrupt_main()
 
     def run_experiment(self):
-        """
-        Wrapper for experiment to catch the softkill function's KeyboardInterrupt signal more gracefully.
-        Do not override.
-        """
-
+        """ Code executed on the child process. """
+        self.init_log()
         data_log_writer = None
 
-        # NOTE: This try/finally IS THE context manager for any cache cleared by self.clear_cache().
+        if not self.disable_shared_memory:
+            # Check that we can connect from the child process.
+            self.exception_manager = SharedMemoryManager(address=EXCEPTION_SERVER_ADDRESS, own=False)
+            self.exception_manager.connect()  # Needs to have already been started.
+            self.stop_event = self.exception_manager.get_event(STOP_EVENT)
+            self.safety_event = self.exception_manager.get_event(SAFETY_EVENT)
+
+        self._event_monitor_barrier = threading.Barrier(parties=2, timeout=DEFAULT_TIMEOUT)
+        self._kill_event_monitor_event = threading.Event()
+        monitor_thread = threading.Thread(target=self.event_monitor, daemon=True)
+        monitor_thread.start()
+
         try:
-            self.init_experiment_log()
+            try:  # Catches SIGINT issued, using _thread.interrupt_main(), by the event_monitor.
+                self._event_monitor_barrier.wait()  # Wait for the monitor_thread to be ready.
 
-            # Set up data log writer
-            data_log_writer = datalogging.DataLogWriter(self.output_path)
-            datalogging.DataLogger.add_writer(data_log_writer)
-
-            # De-restrict device cache access.
-            global devices
-            with devices:
-                # Allow pre_experiment() to cache some devices to test for persistence (dev assertions only).
-                self._persistence_checker = {}
+                # Set up data log writer
+                data_logger_path = os.path.join(self.output_path, self.name.replace(" ", "_").lower() + "_data_logger")
+                data_log_writer = datalogging.DataLogWriter(data_logger_path)
+                datalogging.DataLogger.add_writer(data_log_writer)
 
                 # Run pre-experiment code, e.g., open devices, run calibrations, etc.
+                self.log.info("Experiment.pre_experiment() running...")
                 self.pre_experiment_return = self.pre_experiment()
-
-                # Assert some devices remained opened.
-                for device in self._persistence_checker.values():
-                    assert device.instrument  # Explicit test that instrument remained open.
+                self.log.info("Experiment.pre_experiment() completed.")
 
                 # Run the core experiment.
+                self.log.info("Experiment.experiment() running...")
                 self.experiment_return = self.experiment()
+                self.log.info("Experiment.experiment() completed.")
 
                 # Run any post-experiment analysis, etc.
+                self.log.info("Experiment.post_experiment() running...")
                 self.post_experiment_return = self.post_experiment()
-        except KeyboardInterrupt:
-            self.log.warning("Child process: caught ctrl-c, raising exception.")
-            raise
-        except Exception as error:
-            self.log.exception(error)
+                self.log.info("Experiment.post_experiment() completed.")
+            except KeyboardInterrupt:
+                if self.safety_event.is_set():
+                    raise SafetyException("Event monitor detected a SAFETY event before experiment completed (join root experiment and/or call teardown to retrieve safety exception).")
+                elif self.safety_event.is_set():
+                    raise StopException("Event monitor detected a STOP event before experiment completed (join root experiment and/or call teardown to retrieve safety exception).")
+                else:
+                    # An actual ctrl-c like interrupt occurred.
+                    raise
+        except (Exception, KeyboardInterrupt):  # KeyboardInterrupt inherits from BaseException not Exception.
+            self.log.exception("Exception caught during Experiment.run_experiment().")
+            if self.stop_all_on_exception:
+                # NOTE: An exception has been raised by the experiment and NOT by the event monitor. We now won't to
+                # kill the event monitor without it calling _thread.interrupt_main(). We do this by setting
+                # self. _kill_event_monitor_event BEFORE setting self.stop_event. Otherwise, setting stop_event would
+                # cause the event monitor to call _thread.interrupt_main() thus killing the main child thread, possibly
+                # before Process.run has a chance to set the exception on the exception manager server.
+                self._kill_event_monitor_event.set()
+                self.stop_event.set()
             raise
         finally:
-            self.clear_cache()
+            # Stop the event monitor.
+            self._kill_event_monitor_event.set()
 
             # Release data log writer
             if data_log_writer:
                 datalogging.DataLogger.remove_writer(data_log_writer)
                 data_log_writer.close()
 
-    @abstractmethod
-    def clear_cache(self):
-        """ Injection layer for deleting any global caches. """
+    def pre_experiment(self, *args, **kwargs):
+        """ This is called immediately BEFORE self.experiment(). """
         pass
 
-    @staticmethod
-    def __smart_sleep(interval, process):
-        """
-        Sleep function that will return false at most 1 second after a process ends.  It sleeps in 1 second increments
-        and checks if the process is alive each time.  Rather than sleeping for the entire interval.  This allows
-        the master script to end when the experiment is finished.
-        Do not override.
+    def experiment(self, *args, **kwargs):
+        """ This is where the experiment gets implemented. All concrete child classes must implement this. """
 
-        :param interval: check_interval from ini.
-        :param process: experiment process to monitor while sleeping.
-        :return: True if monitoring should continue, False if the experiment is done.
-        """
-        sleep_count = 0
-        while process.is_alive():
-            time.sleep(1)
-            sleep_count += 1
-            if sleep_count == interval:
-                return True
-        return False
-
-    @abstractmethod
-    def init_experiment_path(self):
-        """ Set up experiment output. Called from start() prior to experiment(). """
+    def post_experiment(self, *args, **kwargs):
+        """ This is called immediately AFTER self.experiment(). """
         pass
 
-    @abstractmethod
-    def init_experiment_log(self):
-        """ Initialize log writing. Called from run_experiment() prior to experiment(). """
+    def init_path(self):
+        """ Set up experiment output. """
+        pass
+
+    def init_log(self):
+        """ Initialize log writing. """
         pass

--- a/catkit/testbed/experiment.py
+++ b/catkit/testbed/experiment.py
@@ -3,7 +3,6 @@ import logging
 import os
 import _thread
 import threading
-import uuid
 
 from catkit import datalogging
 from catkit.multiprocessing import DEFAULT_TIMEOUT, EXCEPTION_SERVER_ADDRESS, Process, SharedMemoryManager

--- a/catkit/testbed/experiment.py
+++ b/catkit/testbed/experiment.py
@@ -1,12 +1,12 @@
 from abc import ABC, abstractmethod
 import logging
 import os
-import _thread
+import signal
 import threading
 
 from catkit import datalogging
 from catkit.multiprocessing import DEFAULT_TIMEOUT, EXCEPTION_SERVER_ADDRESS, Process, SharedMemoryManager
-
+from catkit.util import raise_signal
 
 STOP_EVENT = "catkit_stop_event"
 FINISH_EVENT = "catkit_soft_stop_event"
@@ -341,8 +341,7 @@ class Experiment:
             if self._kill_event_monitor_event.is_set():
                 return
             # Interrupt the main thread with a KeyboardInterrupt exception.
-            # NOTE: This won't interrupt time.sleep(). See https://docs.python.org/3/library/time.html#time.sleep
-            _thread.interrupt_main()
+            raise_signal(signal.SIGINT)
 
     def run_experiment(self):
         """ Code executed on the child process. """

--- a/catkit/testbed/tests/test_experiment.py
+++ b/catkit/testbed/tests/test_experiment.py
@@ -1,0 +1,71 @@
+import time
+
+import pytest
+
+from catkit.testbed.experiment import Experiment, SafetyException, SafetyTest, Testbed
+
+
+def interruptible_sleep(seconds):
+    counter = 0
+    while counter < seconds:
+        time.sleep(1)
+        counter += 1
+
+
+class ExperimentTest(Experiment):
+    name = "Test Experiment"
+
+    def __init__(self, *args, sleep=2, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.test_sleep = sleep
+
+    def experiment(self, *args, **kwargs):
+        interruptible_sleep(self.test_sleep)
+
+
+class NonFailingSafetyTest(SafetyTest):
+    def check(self):
+        pass
+
+
+@pytest.mark.dont_own_exception_handler
+def test_monitor(tmpdir):
+    with Testbed(safety_tests=[NonFailingSafetyTest], output_path=tmpdir):
+        experiment = ExperimentTest(output_path=tmpdir)
+        experiment.start()
+        experiment.join()
+
+
+class FailingSafetyTest(SafetyTest):
+    def check(self):
+        raise SafetyException("FAIL")
+
+
+@pytest.mark.dont_own_exception_handler
+def test_initial_safety_fail_during_setup(tmpdir):
+    with pytest.raises(SafetyException, match="FAIL"):
+        with Testbed(safety_tests=[FailingSafetyTest], output_path=tmpdir):
+            pass
+
+
+class DelayedFailingSafetyTest(SafetyTest):
+    def __init__(self):
+        super().__init__()
+        self.call_counter = 0
+
+    def check(self):
+        self.call_counter += 1
+        if self.call_counter > 1:
+            raise SafetyException(f"FAILING (on {self.call_counter} fail)")
+
+
+@pytest.mark.dont_own_exception_handler
+def test_safety_fail_during_run(tmpdir):
+    experiment = ExperimentTest(sleep=10, output_path=tmpdir)
+    t0 = time.time()
+    with pytest.raises(SafetyException, match="FAILING \\(on [0-9]+ fail\\)"):
+        with Testbed(safety_tests=[DelayedFailingSafetyTest], output_path=tmpdir, safety_check_interval=3):
+            experiment.start()
+            experiment.join()
+
+    assert time.time() - t0 < 10*1.1  # 10%

--- a/catkit/testbed/tests/test_shared_device_cache.py
+++ b/catkit/testbed/tests/test_shared_device_cache.py
@@ -1,0 +1,584 @@
+import os
+
+import multiprocess
+from multiprocess.context import TimeoutError
+from multiprocess.managers import BaseProxy, RemoteError
+import pytest
+import threading
+import time
+
+from catkit.emulators.npoint_tiptilt import SimNPointLC400
+from catkit.multiprocessing import MutexedNamespace, Process, SharedMemoryManager
+from catkit.testbed.caching import DeviceCache, DeviceCacheEnum, SharedSingletonDeviceCache
+
+
+TIMEOUT = 2
+
+
+def test_mutexed_instrument():
+    def thread_func(dev):
+        mutex = dev.get_mutex()
+        with mutex:
+            dev.a = 3
+            time.sleep(mutex.timeout*2)
+
+    dev = SimNPointLC400(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+    assert hasattr(dev, "_catkit_mutex")
+    assert dev.get_mutex().timeout == TIMEOUT
+
+    thread = threading.Thread(target=thread_func, args=(dev,))
+    thread.start()
+    with pytest.raises(TimeoutError, match="Failed to acquire lock"):
+        assert dev.a == 3
+    thread.join()
+
+
+# def test_OwnedContext():
+#     dev = SimNPointLC400(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+#     assert hasattr(dev, "_catkit_mutex")
+#
+#     new = type(dev).__new__(type(dev))
+#
+#     assert hasattr(new, "_catkit_mutex"), type(dev).__mro__
+#
+#     owned_dev = DeviceCache.OwnedContext(dev)
+#     assert hasattr(owned_dev._owned_obj, "_catkit_mutex")
+
+
+def test_singleton_independence():
+    class DeviceCacheA(SharedSingletonDeviceCache):
+        instance = None
+        callbacks = {}
+        aliases = {}
+
+    class DeviceCacheB(SharedSingletonDeviceCache):
+        instance = None
+        callbacks = {}
+        aliases = {}
+
+    @DeviceCacheA.link(key="a")
+    def foo():
+        pass
+
+    @DeviceCacheB.link(key="b")
+    def bar():
+        pass
+
+    assert "a" in DeviceCacheA.callbacks
+    assert "b" in DeviceCacheB.callbacks
+
+    assert "b" not in DeviceCacheA.callbacks
+    assert "a" not in DeviceCacheB.callbacks
+
+    assert DeviceCacheA() is DeviceCacheA()
+    assert DeviceCacheA() is not DeviceCacheB()
+
+    assert DeviceCacheA.callbacks is DeviceCacheA().callbacks
+    assert "a" in DeviceCacheA().callbacks
+    assert "b" in DeviceCacheB().callbacks
+
+    assert "b" not in DeviceCacheA().callbacks
+    assert "a" not in DeviceCacheB().callbacks
+
+
+def test_post_instantiation_linkage():
+    class DeviceCacheA(SharedSingletonDeviceCache):
+        instance = None
+        callbacks = {}
+        aliases = {}
+
+    @DeviceCacheA.link(key="a")
+    def foo():
+        pass
+
+    assert "a" in DeviceCacheA().callbacks
+
+    @DeviceCacheA.link(key="c")
+    def bar():
+        pass
+
+    assert "a" in DeviceCacheA().callbacks
+    assert "c" in DeviceCacheA().callbacks
+
+
+def test_callback():
+    class DeviceCacheA(SharedSingletonDeviceCache):
+        instance = None
+        callbacks = {}
+        aliases = {}
+
+    @DeviceCacheA.link(key="a")
+    def foo():
+        return SimNPointLC400(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+
+    assert "a" in DeviceCacheA.callbacks
+    assert "a" in DeviceCacheA().callbacks
+
+    cache = DeviceCacheA()
+    assert hasattr(cache, "data")
+    assert cache is DeviceCacheA()
+    assert DeviceCacheA() is DeviceCacheA()
+    assert cache is DeviceCacheA.instance
+
+    assert "a" not in cache
+    assert isinstance(cache["a"], SimNPointLC400)
+    assert "a" in cache
+    assert "a" in cache.data
+
+    assert "a" in DeviceCacheA.instance.data
+
+    cacheA = DeviceCacheA()
+    assert cache is cacheA
+    assert "a" in cacheA
+    assert "a" in cacheA.data
+    assert cache.callbacks is DeviceCacheA.callbacks
+    assert cache.callbacks is DeviceCacheA().callbacks
+    assert cache.data is DeviceCacheA().data
+    assert "a" in DeviceCacheA()
+    assert DeviceCacheA()["a"] is foo()
+
+
+def test_enum_default_cache():
+    class DeviceCacheA(SharedSingletonDeviceCache):
+        instance = None
+        callbacks = {}
+        aliases = {}
+
+    class Device(DeviceCacheEnum):
+        DEV_A = ("description", "config_id")
+
+        @staticmethod
+        def default_cache():
+            return DeviceCacheA()
+
+    @Device.DEV_A.link()
+    def foo():
+        return SimNPointLC400(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+
+    assert not Device.DEV_A.cache
+    assert Device.DEV_A.instrument
+    assert DeviceCacheA()[Device.DEV_A] is foo()
+    assert DeviceCacheA()[Device.DEV_A.name] is foo()
+    assert foo() is foo()
+
+
+def test_enum_independent_cache():
+    class DeviceCacheA(SharedSingletonDeviceCache):
+        instance = None
+        callbacks = {}
+        aliases = {}
+
+    class DeviceCacheB(SharedSingletonDeviceCache):
+        instance = None
+        callbacks = {}
+        aliases = {}
+
+    class Device(DeviceCacheEnum):
+        DEV_A = ("description", "config_id")
+        DEV_B = ("description", "config_id", DeviceCacheB)
+
+        @staticmethod
+        def default_cache():
+            return DeviceCacheA()
+
+    @Device.DEV_A.link()
+    def foo():
+        return SimNPointLC400(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+
+    @Device.DEV_B.link()
+    def bar():
+        return SimNPointLC400(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+
+    assert Device.DEV_A.instrument
+    assert DeviceCacheA()[Device.DEV_A] is foo()
+    assert DeviceCacheA()[Device.DEV_A.name] is foo()
+    assert foo() is foo()
+
+    assert Device.DEV_B.instrument
+    assert DeviceCacheB()[Device.DEV_B] is bar()
+    assert DeviceCacheB()[Device.DEV_B.name] is bar()
+    assert bar() is bar()
+
+    assert bar() is not foo()
+    assert DeviceCacheA() is not DeviceCacheB()
+
+    assert Device.DEV_A in DeviceCacheA()
+    assert Device.DEV_B in DeviceCacheB()
+
+    assert Device.DEV_A not in DeviceCacheB()
+    assert Device.DEV_B not in DeviceCacheA()
+
+
+# The following needs to be non-local such that the child process has access to the definitions.
+# This aspect also complicates its use with a fixture to "reset" any instance state.
+class RemoteDeviceCache(SharedSingletonDeviceCache):
+    instance = None
+    callbacks = {}
+    aliases = {}
+    address = ("127.0.0.1", 6007)
+    timeout = TIMEOUT
+
+
+SharedMemoryManager.register("RemoteDeviceCache", callable=RemoteDeviceCache, proxytype=RemoteDeviceCache.Proxy, create_method=True)
+
+
+class RemoteDevice(DeviceCacheEnum):
+    DEV_A = ("description", "config_id", RemoteDeviceCache)
+
+
+class RemoteDeviceB(DeviceCacheEnum):
+    DEV_A = ("description", "config_id", RemoteDeviceCache)
+
+
+class Dev(SimNPointLC400):
+    def getpid(self):
+        return os.getpid()
+
+
+@RemoteDevice.DEV_A.link(aliases=("a",))
+def foo():
+    return Dev(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+
+
+@pytest.fixture(scope="function", autouse=False)
+def remote_caching():
+    global RemoteDeviceCache
+    yield
+
+    # Reset the cache object.
+    RemoteDeviceCache.instance = None
+
+    # Since the above cache object was reset, the enum members should no longer ref it.
+    for member in RemoteDevice:
+        object.__setattr__(member, "cache", None)
+
+
+def test_thread_mutex():
+    def client_func(thread_mutex, proc_mutex):
+        assert thread_mutex.acquire(timeout=TIMEOUT*2)
+        assert proc_mutex.acquire(timeout=TIMEOUT*2)
+
+    thread_mutex = threading.RLock()
+    proc_mutex = multiprocess.RLock()
+
+    client = threading.Thread(target=client_func, args=(thread_mutex, proc_mutex))
+    client.start()
+    assert not thread_mutex.acquire(timeout=TIMEOUT)
+    assert not proc_mutex.acquire(timeout=TIMEOUT)
+    client.join()
+
+
+# def test_proc_mutex():
+#     def client_func(thread_mutex, proc_mutex):
+#         #assert thread_mutex.acquire(timeout=TIMEOUT*2)
+#         assert proc_mutex.acquire(timeout=TIMEOUT*2)
+#
+#     thread_mutex = threading.RLock()
+#     proc_mutex = multiprocess.RLock()
+#
+#     client = Process(target=client_func, args=(thread_mutex, proc_mutex))
+#     client.start()
+#     time.sleep(0.5)
+#     assert thread_mutex.acquire(timeout=TIMEOUT)
+#     assert proc_mutex.acquire(timeout=TIMEOUT)
+#     client.join()
+
+
+def test_device_mutex_over_threads():
+    def client_func(device):
+        assert device.acquire(timeout=TIMEOUT*2)
+
+    naked_dev = SimNPointLC400(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+
+    client = threading.Thread(target=client_func, args=(naked_dev,))
+    client.start()
+    with pytest.raises(TimeoutError, match="Failed to acquire lock"):
+        naked_dev.acquire(timeout=TIMEOUT)
+    client.join()
+
+
+def test_device_mutex_over_proc():
+    def client_func(device):
+        assert device.acquire(timeout=TIMEOUT)
+
+    naked_dev = SimNPointLC400(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+
+    client = Process(target=client_func, args=(naked_dev,))
+    client.start()
+    with pytest.raises(TimeoutError, match="Failed to acquire lock"):
+        # threading syncs can't be used between procs - hence the reason for the shared memory managers.
+        client.join()
+
+
+def test_mutex_over_conn():
+    with SharedMemoryManager() as manager:
+        dic = manager.MutexedDict(timeout=TIMEOUT)
+        local_namespace = MutexedNamespace(timeout=TIMEOUT)
+        remote_namespace = manager.MutexedNamespace(timeout=TIMEOUT)
+
+        local_namespace.a = 2
+        remote_namespace.a = 3
+
+        dic[1] = remote_namespace
+        assert dic[1].a == 3
+
+        dic[1] = local_namespace
+        with pytest.raises((RemoteError, TimeoutError), match="Failed to acquire lock"):
+            assert dic[1].a == 2
+
+
+def test_device_server(remote_caching):
+    with SharedMemoryManager(address=RemoteDeviceCache.address, timeout=TIMEOUT) as manager:
+        # Instantiate cache on remote server. Calls to link() need to happen prior to this.
+        assert isinstance(RemoteDeviceCache(), BaseProxy)
+
+        # Test remoteness of server and cache and that the cache is on the correct server.
+        assert os.getpid() != manager.getpid()
+        assert RemoteDeviceCache()._manager.getpid() == manager.getpid()
+
+        # Test singleton - returns same server-side ID for each instantiation.
+        cache_id = RemoteDeviceCache()._id
+        assert RemoteDeviceCache()._id == cache_id
+
+        # Test that the remote dict aspect of the cache is at least working as expected.
+        naked_dev = SimNPointLC400(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+        naked_dev.pid = os.getpid()
+        RemoteDeviceCache()["a"]# = naked_dev  # Put device on server from client.
+
+        # Test server returns proxy for device.
+        assert isinstance(RemoteDeviceCache()["a"], BaseProxy)
+
+        # Test that the same server-side object gets returned.
+        a_id = RemoteDeviceCache()["a"]._id
+        assert RemoteDeviceCache()["a"]._id == a_id
+
+        # Test del.
+        del RemoteDeviceCache()[RemoteDevice.DEV_A]# "a"]
+        assert "a" not in RemoteDeviceCache()
+
+
+def test_auto_load_func_equivalence(remote_caching):
+    with SharedMemoryManager(address=RemoteDeviceCache.address, timeout=TIMEOUT) as manager:
+        # Test auto load and linked func equivalence.
+        assert not isinstance(foo(), BaseProxy)  # Pre cache lookup so just returns (local) linked wrapper.
+        assert isinstance(RemoteDeviceCache()[RemoteDevice.DEV_A], BaseProxy)
+        assert isinstance(foo(), BaseProxy)  # Post cache lookup so returns (proxy to) linked item cached on the server.
+        assert RemoteDeviceCache()[RemoteDevice.DEV_A]._id == foo()._id
+        # NOTE: Multiple proxies instances point to same referent.
+        assert RemoteDeviceCache()[RemoteDevice.DEV_A] is not foo()
+
+
+def test_device_cache_namespace_access(remote_caching):
+    with SharedMemoryManager(address=RemoteDeviceCache.address, timeout=TIMEOUT) as manager:
+        print("####", os.getpid(), manager.getpid())
+
+        cache = RemoteDeviceCache()
+        assert isinstance(cache, BaseProxy)
+        assert RemoteDeviceCache()._id == cache._id
+
+        device = RemoteDeviceCache()[RemoteDevice.DEV_A]
+        assert isinstance(device, BaseProxy)
+
+        assert "get_mutex" in dir(device)
+        assert device._method_to_typeid_["get_mutex"] == "MutexProxy"
+
+        mutex = device._callmethod("get_mutex")
+        assert isinstance(mutex, BaseProxy)
+
+        assert isinstance(device.get_mutex(), BaseProxy), dir(device)
+        assert device.getpid() == manager.getpid()
+
+        # Test proxy namespace attribute access.
+        RemoteDeviceCache()[RemoteDevice.DEV_A].new_attr = 44
+        # Test that "new_attr" was added to the remote object and not the proxy.
+        assert "new_attr" not in RemoteDeviceCache()[RemoteDevice.DEV_A].__dict__
+        assert RemoteDeviceCache()[RemoteDevice.DEV_A].new_attr == 44
+
+        assert RemoteDeviceCache()[RemoteDevice.DEV_A].instrument
+
+        # Test device.func() gets called server-side.
+        assert RemoteDeviceCache()[RemoteDevice.DEV_A].getpid() == manager.getpid()
+
+
+def test_from_child_process(remote_caching):
+    def child_func(parent_pid):
+        assert RemoteDeviceCache()[RemoteDevice.DEV_A].parent_attr == parent_pid
+        RemoteDeviceCache()[RemoteDevice.DEV_A].child_attr = os.getpid()
+
+    with SharedMemoryManager(address=RemoteDeviceCache.address, timeout=TIMEOUT):
+        RemoteDeviceCache()[RemoteDevice.DEV_A].parent_attr = os.getpid()
+
+        parent_pid = os.getpid()
+        child_proc = Process(target=child_func, args=(parent_pid,))
+        # Start default addressed SharedMemoryManagerProcess to collect child exceptions from Process.
+        with SharedMemoryManager(timeout=TIMEOUT):
+            child_proc.start()
+
+            child_pid = child_proc.pid
+            assert child_pid != parent_pid
+
+            child_proc.join()
+
+        assert RemoteDevice.DEV_A.child_attr == child_pid
+
+
+def client_lock_timeout(parent_pid):
+    with pytest.raises((RemoteError, TimeoutError)):
+        assert RemoteDevice.DEV_A.acquire()
+
+    with pytest.raises((RemoteError, TimeoutError)):
+        assert RemoteDevice.DEV_A.parent_attr == parent_pid
+
+    with pytest.raises((RemoteError, TimeoutError)):
+        RemoteDevice.DEV_A.child_attr = os.getpid()
+
+
+def client_lock(parent_pid):
+    with RemoteDevice.DEV_A as is_locked:
+        assert is_locked
+
+    assert RemoteDevice.DEV_A.parent_attr == parent_pid
+
+    RemoteDevice.DEV_A.child_attr = os.getpid()
+
+
+def test_enum_api(remote_caching):
+    with SharedMemoryManager(address=RemoteDeviceCache.address, timeout=TIMEOUT):
+
+        assert RemoteDevice.DEV_A.instrument
+
+        RemoteDevice.DEV_A.parent_attr = os.getpid()
+        assert RemoteDeviceCache()[RemoteDevice.DEV_A].parent_attr == os.getpid()
+        assert RemoteDevice.DEV_A.parent_attr == os.getpid()
+        assert foo().parent_attr == os.getpid()
+
+        # Test locks.
+        try:
+            outer_lock = None
+            outer_lock = RemoteDevice.DEV_A.acquire()
+            assert outer_lock
+            with RemoteDevice.DEV_A as inner_lock:
+                assert inner_lock
+                try:
+                    inner_most_lock = None
+                    inner_most_lock = RemoteDevice.DEV_A.acquire()
+                    assert inner_most_lock
+                finally:
+                    if inner_most_lock:
+                        RemoteDevice.DEV_A.release()
+        finally:
+            if outer_lock:
+                RemoteDevice.DEV_A.release()
+
+
+def test_enum_api_from_child_process(remote_caching):
+    with SharedMemoryManager(address=RemoteDeviceCache.address, timeout=TIMEOUT):
+
+        RemoteDevice.DEV_A.parent_attr = os.getpid()
+
+        client = Process(target=client_lock_timeout, args=(os.getpid(),))
+        with RemoteDevice.DEV_A as is_locked:
+            assert is_locked
+            client.start()
+            client.join()
+
+        client = Process(target=client_lock, args=(os.getpid(),))
+        client.start()
+        client_pid = client.pid
+        client.join()
+        assert RemoteDevice.DEV_A.child_attr == client_pid
+
+        client = Process(target=client_lock_timeout, args=(os.getpid(),))
+        try:
+            outer_lock = None
+            outer_lock = RemoteDevice.DEV_A.acquire(timeout=TIMEOUT)
+            assert outer_lock
+            client.start()
+            client.join()
+        finally:
+            if outer_lock:
+                RemoteDevice.DEV_A.release()
+
+        client = Process(target=client_lock, args=(os.getpid(),))
+        client.start()
+        client_pid = client.pid
+        client.join()
+        assert RemoteDevice.DEV_A.child_attr == client_pid
+
+
+def test_enum_mutual_cache(remote_caching):
+    with SharedMemoryManager(address=RemoteDeviceCache.address, timeout=TIMEOUT):
+        RemoteDevice.DEV_A.attr1 = 1234567
+        assert RemoteDeviceB.DEV_A.attr1 == 1234567
+
+
+def test_enum_equivalence(remote_caching):
+    assert RemoteDevice(RemoteDeviceB.DEV_A) is RemoteDevice.DEV_A
+    assert RemoteDeviceB(RemoteDevice.DEV_A) is RemoteDeviceB.DEV_A
+
+
+class RemoteDeviceC(DeviceCacheEnum):
+    DEV_B = ("B", "config_id_B", RemoteDeviceCache)
+    DEV_C = ("C", "config_id_C", RemoteDeviceCache)
+    DEV_D = ("D", "config_id_D", RemoteDeviceCache)
+
+
+@pytest.fixture(scope="function", autouse=False)
+def remote_cachingC():
+    global RemoteDeviceCache
+    yield
+
+    # Reset the cache object.
+    RemoteDeviceCache.instance = None
+
+    # Since the above cache object was reset, the enum members should no longer ref it.
+    for member in RemoteDeviceC:
+        object.__setattr__(member, "cache", None)
+
+
+@RemoteDeviceC.DEV_B.link()
+def fooA():
+    return Dev(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+
+
+@RemoteDeviceC.DEV_C.link()
+def fooB():
+    return Dev(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+
+
+@RemoteDeviceC.DEV_D.link()
+def fooC():
+    return Dev(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+
+
+def test_keys(remote_cachingC):
+    with SharedMemoryManager(address=RemoteDeviceCache.address, timeout=TIMEOUT):
+        RemoteDeviceC.open_all()
+        assert RemoteDeviceCache().keys() == [member.name for member in RemoteDeviceC]
+
+
+def test_values(remote_cachingC):
+    with SharedMemoryManager(address=RemoteDeviceCache.address, timeout=TIMEOUT):
+        RemoteDeviceCache().open_all()
+        for value in RemoteDeviceCache().values():
+            assert isinstance(value, BaseProxy)
+
+
+def test_items(remote_cachingC):
+    with SharedMemoryManager(address=RemoteDeviceCache.address, timeout=TIMEOUT):
+        RemoteDeviceCache().open_all()
+        items = RemoteDeviceCache().items()
+        for key, value in items:
+            assert isinstance(value, BaseProxy)
+            assert RemoteDeviceCache()[key]._id == value._id
+
+
+def test_pop(remote_cachingC):
+    with SharedMemoryManager(address=RemoteDeviceCache.address, timeout=TIMEOUT):
+        RemoteDeviceCache().open_all()
+        length = len(RemoteDeviceCache())
+        assert isinstance(RemoteDeviceCache().pop(RemoteDeviceC.DEV_C), BaseProxy)
+        assert len(RemoteDeviceCache()) == length - 1
+        assert RemoteDeviceC.DEV_C not in RemoteDeviceCache()
+        assert RemoteDeviceC.DEV_B in RemoteDeviceCache()
+        assert RemoteDeviceC.DEV_D in RemoteDeviceCache()

--- a/catkit/testbed/tests/test_shared_device_cache.py
+++ b/catkit/testbed/tests/test_shared_device_cache.py
@@ -9,7 +9,7 @@ import time
 
 from catkit.emulators.npoint_tiptilt import SimNPointLC400
 from catkit.multiprocessing import MutexedNamespace, Process, SharedMemoryManager
-from catkit.testbed.caching import DeviceCache, DeviceCacheEnum, SharedSingletonDeviceCache
+from catkit.testbed.caching import DeviceCacheEnum, SharedSingletonDeviceCache
 
 
 TIMEOUT = 2

--- a/catkit/testbed/tests/test_shared_device_cache.py
+++ b/catkit/testbed/tests/test_shared_device_cache.py
@@ -506,6 +506,23 @@ def test_enum_api_from_child_process(remote_caching):
         assert RemoteDevice.DEV_A.child_attr == client_pid
 
 
+def test_enum_api_lock_all(remote_caching):
+    with SharedMemoryManager(address=RemoteDeviceCache.address, timeout=TIMEOUT):
+
+        RemoteDevice.DEV_A.parent_attr = os.getpid()
+
+        client = Process(target=client_lock_timeout, args=(os.getpid(),))
+        with RemoteDevice.lock_all() as all_locked:
+            assert all_locked
+            client.start()
+            client.join()
+
+        # Test all were released.
+        client = Process(target=client_lock, args=(os.getpid(),))
+        client.start()
+        client.join()
+
+
 def test_enum_mutual_cache(remote_caching):
     with SharedMemoryManager(address=RemoteDeviceCache.address, timeout=TIMEOUT):
         RemoteDevice.DEV_A.attr1 = 1234567

--- a/catkit/testbed/tests/test_shared_state.py
+++ b/catkit/testbed/tests/test_shared_state.py
@@ -1,23 +1,31 @@
 import os
-import psutil
+import threading
 import time
 import uuid
 
 from astropy.io import fits
 from multiprocess.context import TimeoutError
-from multiprocess.managers import ListProxy
+from multiprocess.managers import BaseProxy, ListProxy, RemoteError
 import numpy as np
 import pytest
 
-from catkit.testbed.caching import SharedState, UserCache
-from catkit.multiprocessing import Process, SharedMemoryManager
+from catkit.testbed.caching import MutexedDict, UserCache
+from catkit.multiprocessing import MutexedNamespaceSingleton, Process, SharedMemoryManager, SharedState, SHARED_STATE_ADDRESS
 
-TIMEOUT = 5  # Use a shorter timeout for testing.
+
+TIMEOUT = 2  # Use a shorter timeout for testing.
+
+
+@pytest.fixture(scope="function", autouse=True)
+def reset_SharedState():
+    SharedState.instance = None
+    yield
+    SharedState.instance = None
 
 
 def test_naked_shared_state():
     def client1_func():
-        manager = SharedMemoryManager()
+        manager = SharedMemoryManager(address=SHARED_STATE_ADDRESS)
         manager.connect()
         shared_state = manager.SharedState()
 
@@ -27,7 +35,7 @@ def test_naked_shared_state():
         shared_state.attribute_from_parent = "mutated from client1"
 
     def client2_func():
-        manager = SharedMemoryManager()
+        manager = SharedMemoryManager(address=SHARED_STATE_ADDRESS)
         manager.connect()
         shared_state = manager.SharedState()
 
@@ -36,7 +44,7 @@ def test_naked_shared_state():
 
         shared_state.attribute_from_client2 = "from client2"
 
-    with SharedMemoryManager() as manager:
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS) as manager:
         client1 = Process(target=client1_func)
         client2 = Process(target=client2_func)
 
@@ -48,8 +56,6 @@ def test_naked_shared_state():
 
         client2.start()
         client2.join()
-
-        print(shared_state.attribute_from_client1, shared_state.attribute_from_client2,shared_state.attribute_from_parent)
 
         assert shared_state.attribute_from_client1 == "from client1"
         assert shared_state.attribute_from_client2 == "from client2"
@@ -73,70 +79,77 @@ def test_SharedState():
 
         shared_state.attribute_from_client2 = "from client2"
 
-    client1 = Process(target=client1_func)
-    client2 = Process(target=client2_func)
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS):
+        client1 = Process(target=client1_func)
+        client2 = Process(target=client2_func)
 
-    shared_state = SharedState(own=True)
+        shared_state = SharedState()
 
-    shared_state.attribute_from_parent = "from parent"
+        shared_state.attribute_from_parent = "from parent"
 
-    client1.start()
-    client1.join()
+        client1.start()
+        client1.join()
 
-    client2.start()
-    client2.join()
+        client2.start()
+        client2.join()
 
-    assert shared_state.attribute_from_client1 == "from client1"
-    assert shared_state.attribute_from_client2 == "from client2"
-    assert shared_state.attribute_from_parent == "mutated from client1"
+        assert shared_state.attribute_from_client1 == "from client1"
+        assert shared_state.attribute_from_client2 == "from client2"
+        assert shared_state.attribute_from_parent == "mutated from client1"
 
 
-def test_shutdown():
-    shared_state = SharedState(own=True)
-    server_pid = shared_state._manager.getpid()
-    assert server_pid in [process.pid for process in psutil.process_iter()]
-
-    del shared_state
-    time.sleep(0.5)
-    assert server_pid not in [process.pid for process in psutil.process_iter()]
+# def test_shutdown():
+#     shared_state = SharedState()
+#     server_pid = shared_state._manager.getpid()
+#     assert server_pid in [process.pid for process in psutil.process_iter()]
+#
+#     del shared_state
+#     time.sleep(0.5)
+#     assert server_pid not in [process.pid for process in psutil.process_iter()]
 
 
 def test_mutex_timeout():
-    def client1_func():
+    def client1_func(barrier):
         shared_state = SharedState()
-        with shared_state:
-            time.sleep(TIMEOUT*1.5)  # Acquire lock for longer than the (default) timeout on client2.
+        assert isinstance(shared_state, BaseProxy)
+        with shared_state as lock_acquired:
+            assert lock_acquired is True
+            barrier.wait()
+            time.sleep(TIMEOUT*2)  # Acquire lock for longer than the (default) timeout on client2.
 
-    def client2_func():
+    def client2_func(barrier):
         shared_state = SharedState()
-        with pytest.raises(TimeoutError):
+        assert isinstance(shared_state, BaseProxy)
+        barrier.wait()
+        with pytest.raises((RemoteError, TimeoutError), match="Failed to acquire lock"):
             with shared_state:
                 pass
 
-    client1 = Process(target=client1_func)
-    client2 = Process(target=client2_func)
-    shared_state = SharedState(own=True, timeout=TIMEOUT)
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS) as manager:
+        barrier = manager.get_barrier("test_mutex_timeout", 2)
 
-    client1.start()
-    time.sleep(0.5)  # Sleep to help client 1 acquire the lock 1st.
-    client2.start()
+        client1 = Process(target=client1_func, args=(barrier,))
+        client2 = Process(target=client2_func, args=(barrier,))
+        shared_state = SharedState()
 
-    client1.join()
-    client2.join()
+        client1.start()
+        client2.start()
+
+        client1.join()
+        client2.join()
 
 
 def test_mutex_timeout2():
     def client1_func():
         shared_state = SharedState()
-        with pytest.raises(TimeoutError):
+        with pytest.raises((RemoteError, TimeoutError), match="Failed to acquire lock"):
             shared_state.from_client = 1
 
-    shared_state = SharedState(own=True, timeout=TIMEOUT)
-
-    with shared_state:
-        client1 = Process(target=client1_func)
-        client1.start()
-        client1.join()
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS):
+        with SharedState():
+            client1 = Process(target=client1_func)
+            client1.start()
+            client1.join()
 
 
 def test_mutex():
@@ -151,18 +164,19 @@ def test_mutex():
         with shared_state:
             shared_state.client2 = 2
 
-    client1 = Process(target=client1_func)
-    client2 = Process(target=client2_func)
-    shared_state = SharedState(own=True)
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS):
+        client1 = Process(target=client1_func)
+        client2 = Process(target=client2_func)
+        shared_state = SharedState()
 
-    client1.start()
-    client2.start()
+        client1.start()
+        client2.start()
 
-    client1.join()
-    client2.join()
+        client1.join()
+        client2.join()
 
-    assert shared_state.client1 == 1
-    assert shared_state.client2 == 2
+        assert shared_state.client1 == 1
+        assert shared_state.client2 == 2
 
 
 class MyCache(UserCache):
@@ -176,7 +190,7 @@ SharedMemoryManager.register("MyCache", callable=MyCache, proxytype=MyCache.Prox
 def test_UserCache():
 
     def client_func(item_from_parent):
-        shared_state = SharedState(own=False)
+        shared_state = SharedState()
         auto_loaded_from_parent = shared_state.my_cache["new_from_parent"]
         assert auto_loaded_from_parent == item_from_parent, f"{auto_loaded_from_parent}, {item_from_parent}"
 
@@ -188,23 +202,53 @@ def test_UserCache():
         assert auto_loaded_from_parent != auto_loaded_from_client
         shared_state.my_cache["from_client"] = 1234
 
-    shared_state = SharedState(own=True)
-    # Instantiate an instance of MyCache on the server and assign its proxy to SharedState.my_cache to access from
-    # any client.
-    shared_state.my_cache = shared_state._manager.MyCache()
-    shared_state.my_cache["from_parent"] = 56789
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS):
+        shared_state = SharedState()
+        # Instantiate an instance of MyCache on the server and assign its proxy to SharedState.my_cache to access from
+        # any client.
+        shared_state.my_cache = shared_state._manager.MyCache()
+        shared_state.my_cache["from_parent"] = 56789
 
-    # Test auto load from parent.
-    auto_loaded_from_parent = shared_state.my_cache["new_from_parent"]
-    assert f"auto populated_{shared_state._manager.getpid()}" in auto_loaded_from_parent
+        # Test auto load from parent.
+        auto_loaded_from_parent = shared_state.my_cache["new_from_parent"]
+        assert f"auto populated_{shared_state._manager.getpid()}" in auto_loaded_from_parent
 
-    client = Process(target=client_func, args=(auto_loaded_from_parent,))
-    client.start()
-    client.join()
+        client = Process(target=client_func, args=(auto_loaded_from_parent,))
+        client.start()
+        client.join()
 
-    assert f"auto populated_{shared_state._manager.getpid()}" in shared_state.my_cache["new_from_client"]
-    assert shared_state.my_cache["new_from_client"] != auto_loaded_from_parent
-    assert shared_state.my_cache["from_client"] == 1234
+        assert f"auto populated_{shared_state._manager.getpid()}" in shared_state.my_cache["new_from_client"]
+        assert shared_state.my_cache["new_from_client"] != auto_loaded_from_parent
+        assert shared_state.my_cache["from_client"] == 1234
+
+
+def test_get_mutex():
+    def client_func():
+        shared_state = SharedState()
+        with pytest.raises((RemoteError, TimeoutError), match="Failed to acquire lock"):
+            assert shared_state.from_parent == 567899
+
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS):
+        shared_state = SharedState()
+        mutex = shared_state.get_mutex()
+        assert isinstance(mutex, BaseProxy)
+        with mutex:
+            shared_state.from_parent = 567899
+
+            client = Process(target=client_func)
+            client.start()
+            client.join()
+
+        with shared_state:
+            client = Process(target=client_func)
+            client.start()
+            client.join()
+
+        with mutex:
+            with shared_state:
+                client = Process(target=client_func)
+                client.start()
+                client.join()
 
 
 def test_MutexedCache():
@@ -216,51 +260,87 @@ def test_MutexedCache():
             with shared_state.my_cache:  # Might as well test the re-entrant-ness.
                 shared_state.my_cache["from_client"] = 1234
 
-    shared_state = SharedState(own=True)
-    # Instantiate an instance of MyCache on the server and assign its proxy to SharedState.my_cache to access from
-    # any client.
-    shared_state.my_cache = shared_state._manager.MutexedCache()
-    with shared_state.my_cache:
-        shared_state.my_cache["from_parent"] = 56789
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS):
+        shared_state = SharedState()    # Instantiate an instance of MyCache on the server and assign its proxy to SharedState.my_cache to access from
+        # any client.
+        assert isinstance(shared_state, BaseProxy)
 
-    client = Process(target=client_func)
-    client.start()
-    client.join()
+        mutexed_dict = shared_state._manager.MutexedDict()
+        assert isinstance(mutexed_dict, BaseProxy)
+        assert mutexed_dict._manager
 
-    assert shared_state.my_cache["from_client"] == 1234
+        # Now pass this to the server - which you can't actually do since we're passing a proxy back and not all of it,
+        # i.e., ``_manager`` gets stripped out as it's not pickleble.
+        shared_state.my_cache = mutexed_dict
+        assert isinstance(shared_state.my_cache, BaseProxy)
+        assert shared_state.my_cache._id == mutexed_dict._id
+        assert shared_state.my_cache is not mutexed_dict
 
+        # Manager has now been stripped. The consequence of this is that no proxy can be returned from ``my_cache`` as
+        # it has no manager from which to build one.
+        assert not shared_state.my_cache._manager
 
-def test_MutexedCache_timeout():
-    def client_func():
-        shared_state = SharedState()
-        with pytest.raises(TimeoutError):
-            shared_state.my_cache["from_client"] = 1234
-
-        with pytest.raises(TimeoutError):
-            with shared_state.my_cache:
-                pass
-
-    shared_state = SharedState(own=True)
-    # Instantiate an instance of MyCache on the server and assign its proxy to SharedState.my_cache to access from
-    # any client.
-    shared_state.my_cache = shared_state._manager.MutexedCache(timeout=TIMEOUT)
-    with shared_state.my_cache:
-        shared_state.my_cache["from_parent"] = 56789
+        with shared_state.my_cache:
+            shared_state.my_cache["from_parent"] = 56789
 
         client = Process(target=client_func)
         client.start()
         client.join()
 
+        assert shared_state.my_cache["from_client"] == 1234
+
+
+def test_thread_safety_MutexedCache_timeout():
+    def client_func(cache, barrier):
+        with cache:
+            barrier.wait()
+            cache["from child"] = 12345
+            time.sleep(TIMEOUT*2)
+
+    cache = MutexedDict(timeout=TIMEOUT)
+
+    barrier = threading.Barrier(parties=2)
+    client = threading.Thread(target=client_func, args=(cache, barrier))
+    client.start()
+    barrier.wait()
+
+    with pytest.raises(TimeoutError, match="Failed to acquire lock"):
+        assert cache["from child"] == 12345
+    client.join()
+
+
+def test_MutexedCache_timeout():
+    def client_func():
+        shared_state = SharedState()
+        with pytest.raises((RemoteError, TimeoutError), match="Failed to acquire lock"):
+            shared_state.my_cache["from_client"] = 1234
+
+        with pytest.raises((RemoteError, TimeoutError), match="Failed to acquire lock"):
+            with shared_state.my_cache:
+                pass
+
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS):
+        shared_state = SharedState()    # Instantiate an instance of MyCache on the server and assign its proxy to SharedState.my_cache to access from
+        # any client.
+        shared_state.my_cache = shared_state._manager.MutexedDict(timeout=TIMEOUT)
+        with shared_state.my_cache:
+            shared_state.my_cache["from_parent"] = 56789
+
+            client = Process(target=client_func)
+            client.start()
+            client.join()
+
 
 def test_normal_dict_update():
-    shared_state = SharedState(own=True)
-    shared_state.my_dict = {}
-    shared_state.my_dict["item_1"] = 1
-    assert shared_state.my_dict.get("item_1") is None
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS):
+        shared_state = SharedState()
+        shared_state.my_dict = {}
+        shared_state.my_dict["item_1"] = 1
+        assert shared_state.my_dict.get("item_1") is None
 
-    shared_state.my_dict = shared_state._manager.dict()
-    shared_state.my_dict["item_1"] = 1
-    assert shared_state.my_dict["item_1"] == 1
+        shared_state.my_dict = shared_state._manager.dict()
+        shared_state.my_dict["item_1"] = 1
+        assert shared_state.my_dict["item_1"] == 1
 
 
 def test_image_transfer():
@@ -271,13 +351,14 @@ def test_image_transfer():
         assert shared_state.image_from_parent.data.shape == shape
         assert np.allclose(shared_state.image_from_parent.data, image_from_parent.data)
 
-    shared_state = SharedState(own=True)
-    image = fits.PrimaryHDU(data=np.random.rand(*shape))
-    shared_state.image_from_parent = image
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS):
+        shared_state = SharedState()
+        image = fits.PrimaryHDU(data=np.random.rand(*shape))
+        shared_state.image_from_parent = image
 
-    client = Process(target=client_func, args=(image,))
-    client.start()
-    client.join()
+        client = Process(target=client_func, args=(image,))
+        client.start()
+        client.join()
 
 
 def test_hdu_list_update():
@@ -291,62 +372,119 @@ def test_hdu_list_update():
         assert image_list[1].data.shape == tuple([n//2 for n in shape])
 
     SharedMemoryManager.register("HDUList", callable=fits.HDUList, proxytype=ListProxy)
-    shared_state = SharedState(own=True)
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS):
+        shared_state = SharedState()
+        # The following will fail to update the HDUList on the server.
+        shared_state.broken_nested_image_list = fits.HDUList()
+        shared_state.broken_nested_image_list.append(fits.PrimaryHDU(data=np.random.rand(*shape)))
+        assert len(shared_state.broken_nested_image_list) == 0
 
-    # The following will fail to update the HDUList on the server.
-    shared_state.broken_nested_image_list = fits.HDUList()
-    shared_state.broken_nested_image_list.append(fits.PrimaryHDU(data=np.random.rand(*shape)))
-    assert len(shared_state.broken_nested_image_list) == 0
+        # However, it'll work if you "put it back".
+        hdu_list = shared_state.broken_nested_image_list
+        hdu_list.append(fits.PrimaryHDU(data=np.random.rand(*shape)))
+        shared_state.broken_nested_image_list = hdu_list
+        assert len(shared_state.broken_nested_image_list) == 1
 
-    # However, it'll work if you "put it back".
-    hdu_list = shared_state.broken_nested_image_list
-    hdu_list.append(fits.PrimaryHDU(data=np.random.rand(*shape)))
-    shared_state.broken_nested_image_list = hdu_list
-    assert len(shared_state.broken_nested_image_list) == 1
+        # The following will get updated.
+        shared_state.nested_image_list = shared_state._manager.HDUList()
+        shared_state.nested_image_list.append(fits.PrimaryHDU(data=np.random.rand(*shape)))
+        shared_state.nested_image_list.append(fits.PrimaryHDU(data=np.random.rand(*[n//2 for n in shape])))
+        assert len(shared_state.nested_image_list) == 2
 
-    # The following will get updated.
-    shared_state.nested_image_list = shared_state._manager.HDUList()
-    shared_state.nested_image_list.append(fits.PrimaryHDU(data=np.random.rand(*shape)))
-    shared_state.nested_image_list.append(fits.PrimaryHDU(data=np.random.rand(*[n//2 for n in shape])))
-    assert len(shared_state.nested_image_list) == 2
+        # However, nesting is inevitable and thus so are failed updates, e.g., the header will not...
+        shared_state.nested_image_list[0].header["my key"] = "updated"
+        assert shared_state.nested_image_list[0].header.get("my key") is None
 
-    # However, nesting is inevitable and thus so are failed updates, e.g., the header will not...
-    shared_state.nested_image_list[0].header["my key"] = "updated"
-    assert shared_state.nested_image_list[0].header.get("my key") is None
-
-    client = Process(target=client_func)
-    client.start()
-    client.join()
+        client = Process(target=client_func)
+        client.start()
+        client.join()
 
 
-class HicatTestbedState(SharedState):
+# The following test the design pattern used for both hicat's sim and testbed-state objects.
+
+class HicatTestbedState(MutexedNamespaceSingleton):
+    instance = None
+
+    address = SHARED_STATE_ADDRESS
+    timeout = TIMEOUT
+
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        if object.__getattribute__(self, "__class__").instance is None:
+            super().__init__(*args, **kwargs)
+            self.background_cache = MutexedDict(lock=self.get_mutex())
+            self.mode = None
+            self.nested_dic = MutexedDict(lock=self.get_mutex())
 
-        if self._own:
-            with self:
-                self.background_cache = self._manager.dict()
-                self.mode = None
+    def get_background_cache(self):
+        return self.background_cache
 
-    @property  # Belongs to the proxy so gets executed locally, i.e., the same process as the caller.
+    def get_nested_dic(self):
+        return self.nested_dic
+
+    @property
+    def background_cache(self):
+        return self._background_cache
+
+    @background_cache.setter
+    def background_cache(self, value):
+        self._background_cache = value
+        # # Clobber existing mutex with that of the parent namespace such that when its proxy is returned it is
+        # # still mutexed (by the parent) even if it's referenced from beyond the parent namespace.
+        #self._background_cache._catkit_mutex = self.get_mutex()
+
+    @property
     def pid(self):
         return os.getpid()
 
+    class Proxy(MutexedNamespaceSingleton.Proxy):
+        _method_to_typeid_ = {}
+        if hasattr(MutexedNamespaceSingleton.Proxy, "_method_to_typeid_"):
+            _method_to_typeid_.update(MutexedNamespaceSingleton.Proxy._method_to_typeid_)
+        _method_to_typeid_.update({"get_background_cache": "MutexedDictProxy",
+                                   "get_nested_dic": "NestedMutexedDictProxy"})
 
-def test_TestbedState():
+        def get_background_cache(self):
+            return self._callmethod("get_background_cache")
+
+        def get_nested_dic(self):
+            return self._callmethod("get_nested_dic")
+
+        @property
+        def background_cache(self):
+            ret = self.get_background_cache()
+            assert isinstance(ret, BaseProxy)
+            return ret
+
+        @property
+        def nested_dic(self):
+            return self.get_nested_dic()
+
+
+SharedMemoryManager.register(HicatTestbedState.__name__, callable=HicatTestbedState, proxytype=HicatTestbedState.Proxy, create_method=True)
+
+
+@pytest.fixture(scope="function", autouse=False)
+def reset_HicatTestbedState():
+    HicatTestbedState.instance = None
+    yield
+    HicatTestbedState.instance = None
+
+
+def test_TestbedState(reset_HicatTestbedState):
 
     def client1_func():
         shared_state = HicatTestbedState()
+        assert isinstance(shared_state, BaseProxy)
+
         with shared_state:
             assert shared_state.mode == "initial mode", shared_state.mode
             shared_state.mode = "client1 mode"
             assert shared_state.mode == "client1 mode"
 
+            assert isinstance(shared_state.background_cache, BaseProxy)
+            #with background_cache:
             shared_state.background_cache["from client 1"] = 12345
             assert shared_state.background_cache["from client 1"] == 12345
-
-            assert shared_state.pid == os.getpid()
-            assert shared_state.pid != shared_state._manager.getpid()
 
     def client2_func():
         shared_state = HicatTestbedState()
@@ -358,32 +496,111 @@ def test_TestbedState():
             shared_state.background_cache["from client 2"] = 6789
             assert shared_state.background_cache["from client 2"] == 6789
 
-            assert shared_state.pid == os.getpid()
-            assert shared_state.pid != shared_state._manager.getpid()
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS) as manager:
+        shared_state = HicatTestbedState()
+        assert isinstance(shared_state, BaseProxy)
+        assert shared_state.get_mutex().timeout == TIMEOUT
+        assert shared_state.background_cache.get_mutex().timeout == TIMEOUT
 
-    shared_state = HicatTestbedState(own=True)
-    assert shared_state.mode is None
-    shared_state.mode = "initial mode"
-    assert shared_state.mode == "initial mode"
+        assert shared_state.mode is None
+        shared_state.mode = "initial mode"
+        assert shared_state.mode == "initial mode"
 
-    assert shared_state.pid == os.getpid()
-    assert shared_state.pid != shared_state._manager.getpid()
+        assert shared_state.pid == manager.getpid()
+        assert shared_state.pid != os.getpid()
 
-    client1 = Process(target=client1_func)
-    client2 = Process(target=client2_func)
+        client1 = Process(target=client1_func)
+        client2 = Process(target=client2_func)
 
-    client1.start()
-    time.sleep(0.5)
-    client2.start()
+        client1.start()
+        time.sleep(0.5)
+        client2.start()
 
-    client1.join()
-    client2.join()
+        client1.join()
+        client2.join()
 
-    assert shared_state.mode == "client1 mode"
-    assert shared_state.background_cache["from client 1"] == 12345
-    assert shared_state.background_cache["from client 2"] == 6789
+        assert shared_state.mode == "client1 mode"
+        assert isinstance(shared_state.background_cache, BaseProxy)
+        assert shared_state.background_cache["from client 1"] == 12345
+        assert shared_state.background_cache["from client 2"] == 6789
+
+        # Test that proxy setter is not required (weak test without spawning another client process).
+        shared_state.background_cache = shared_state._manager.MutexedDict({1: 345}, timeout=TIMEOUT)
+        cache = shared_state.background_cache
+        assert cache[1] == 345
+        background_cache = shared_state.get_background_cache()
+        assert isinstance(background_cache, BaseProxy)
+        assert background_cache[1] == 345
 
 
-if __name__ == "__main__":
-    test_TestbedState()
+def test_co_mutex(reset_HicatTestbedState):
+    def client1_func():
+        shared_state = HicatTestbedState()
+        with shared_state:
+            manager.get_barrier("mutex_acquired_from_client", 2).wait()
+            time.sleep(TIMEOUT*5)
 
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS) as manager:
+        shared_state = HicatTestbedState()
+        assert shared_state.get_mutex().timeout == TIMEOUT
+
+        background_cache = shared_state.background_cache
+
+        assert background_cache.get_mutex() == shared_state.nested_dic.get_mutex()
+        assert background_cache.get_mutex() == shared_state.get_mutex()
+        assert background_cache.get_mutex().timeout == TIMEOUT
+
+        client1 = Process(target=client1_func)
+        client1.start()
+        manager.get_barrier("mutex_acquired_from_client", 2).wait()
+        with pytest.raises((RemoteError, TimeoutError), match="Failed to acquire lock"):
+            background_cache["test"] = 2
+
+        client1.join()
+
+
+def test_access_time(reset_HicatTestbedState):
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS) as manager:
+        shared_state = HicatTestbedState()
+
+        n = 50
+
+        t0_all = time.time()
+        for i in range(n):
+            t0 = time.time()
+            #shared_state.background_cache[i] = i
+            shared_state.m = i
+            t_set = time.time()
+            #shared_state.background_cache[i]
+            shared_state.m
+            t_get = time.time()
+
+            t_exp_set = (t_set - t0)*1e6
+            t_exp_get = (t_get - t_set)*1e6
+            print(i, t_exp_set, t_exp_get)
+        t_all = (time.time() - t0_all)*1e6
+        print("total (us)", t_all, t_all/n)
+        mean_time = t_all/n
+        limit = 600  # Adhoc.
+        assert mean_time < 600, f"mean rt for sequential set & get: {mean_time} < {limit}"
+        #assert False
+
+
+def test_nested_dict(reset_HicatTestbedState):
+    def client_func():
+        shared_state = HicatTestbedState()
+        assert shared_state.nested_dic["from parent"]._getvalue() == {1: 1, 2: 2}
+        shared_state.nested_dic["from parent"][1] = 3
+
+    with SharedMemoryManager(address=SHARED_STATE_ADDRESS) as manager:
+        shared_state = HicatTestbedState()
+        assert isinstance(shared_state.nested_dic, BaseProxy)
+
+        nested_dic = shared_state.nested_dic
+        nested_dic["from parent"] = manager.MutexedDict({1: 1, 2: 2})
+
+        client = Process(target=client_func)
+        client.start()
+        client.join()
+
+        assert nested_dic["from parent"][1] == 3

--- a/catkit/testbed/tests/test_shared_state.py
+++ b/catkit/testbed/tests/test_shared_state.py
@@ -588,7 +588,7 @@ def test_access_time(reset_HicatTestbedState):
 
         limit = 600  # Adhoc (achievable when test was first added (run on Late 2013 MacPro)).
         assert round_trip < 600, f"mean rt for sequential set & get: {round_trip:.2f} > {limit}"
-        assert False
+        # assert False
 
 
 # shape, limit = (712, 712), 50  # Image.

--- a/catkit/testbed/tests/test_shared_state.py
+++ b/catkit/testbed/tests/test_shared_state.py
@@ -607,15 +607,15 @@ def test_Mbps(reset_HicatTestbedState, shape, limit):
         t_get = [0]*n
 
         for i in range(n):
-            t0 = time.time()
+            t0 = time.perf_counter_ns()
             shared_state.m = data
-            t1 = time.time()
-            t_set[i] = t1 - t0
+            t1 = time.perf_counter_ns()
+            t_set[i] = (t1 - t0)*1e-9
 
-            t0 = time.time()
+            t0 = time.perf_counter_ns()
             _resp = shared_state.m
-            t1 = time.time()
-            t_get[i] = t1 - t0
+            t1 = time.perf_counter_ns()
+            t_get[i] = (t1 - t0)*1e-9
 
             print(f"{i}: {n_Mb/t_set[i]:.2f}Mbps {n_Mb/t_get[i]:.2f}Mbps")
         mean_get_mbps = n_Mb/np.mean(t_get)

--- a/catkit/testbed/tests/test_shared_state.py
+++ b/catkit/testbed/tests/test_shared_state.py
@@ -13,6 +13,7 @@ import pytest
 from catkit.testbed.caching import MutexedDict, UserCache
 from catkit.multiprocessing import MutexedNamespaceSingleton, Process, SharedMemoryManager, SharedState, SHARED_STATE_ADDRESS
 
+CI = os.environ.get('CI') in ('True', 'true')
 
 TIMEOUT = 2  # Use a shorter timeout for testing.
 
@@ -560,6 +561,7 @@ def test_co_mutex(reset_HicatTestbedState):
         client1.join()
 
 
+@pytest.mark.skipif(CI, reason="Perf tests")
 def test_access_time(reset_HicatTestbedState):
     with SharedMemoryManager(address=SHARED_STATE_ADDRESS) as manager:
         shared_state = HicatTestbedState()
@@ -593,6 +595,7 @@ def test_access_time(reset_HicatTestbedState):
 
 # shape, limit = (712, 712), 50  # Image.
 # shape, limit = ((34, 34, 2)), 1000  # Double Boston Dm command.
+@pytest.mark.skipif(CI, reason="Perf tests")
 @pytest.mark.parametrize(("shape", "limit"), (((712, 712), 50), ((34, 34, 2), 1000)))
 def test_Mbps(reset_HicatTestbedState, shape, limit):
     with SharedMemoryManager(address=SHARED_STATE_ADDRESS) as manager:

--- a/catkit/tests/test_multiprocessing.py
+++ b/catkit/tests/test_multiprocessing.py
@@ -1,26 +1,26 @@
+import copy
 import os
-from threading import BrokenBarrierError
+from threading import BrokenBarrierError, Thread
 import time
 
 from multiprocess.context import TimeoutError
-from multiprocess.managers import State
-import numpy as np
+from multiprocess.managers import BaseProxy, NamespaceProxy, State
 import pytest
 
-from catkit.multiprocessing import Process, SharedMemoryManager
+from catkit.emulators.npoint_tiptilt import SimNPointLC400
+from catkit.multiprocessing import Mutex, Process, SharedMemoryManager
 
-TIMEOUT = 10  # Use a shorter timeout for testing.
+TIMEOUT = 5  # Use a shorter timeout for testing.
 
 
 def test_child_exception():
     def client_func():
         raise RuntimeError("123456789")
 
-    with SharedMemoryManager() as manager:
-        client = Process(target=client_func)
-        client.start()
-        with pytest.raises(RuntimeError, match="123456789"):
-            client.join()
+    client = Process(target=client_func)
+    client.start()
+    with pytest.raises(RuntimeError, match="123456789"):
+        client.join()
 
 
 def test_pid():
@@ -73,59 +73,233 @@ def test_locks():
             client.join()
 
 
-def client_barrier(sleep, parties, a_list, name_mangle=False):
+def test_RLock_is_renterant_per_connection_and_process():
+
+    # BaseProxy caches connections per server address, so multiple proxies will use the exact same connection object.
+    # Since these are cached as a class attribute, a separate cache exits per process (otherwise non of this would even be needed).
+    # The server is started on a separate process which it then spins up a thread to accept connections which that in turn
+    # spins up a new thread per connection from a client. The server has a thread per client connection.
+    # Shared reentrant locks are just threading.RLock instances that exist on the server process but on a specific
+    # client thread - for which these locks are reentrant only to a single given thread.
+    # Since their proxy calls `acquire()` and `release()` on the server (not the client) it would need to
+    # be threaded such that it is reentrant per process and thus not invalidating the lock entirely.
+
+    with SharedMemoryManager() as manager:
+        lock1 = manager.get_lock("my_lock")
+        lock1.acquire(timeout=TIMEOUT)
+
+        # New connection.
+        manager2 = SharedMemoryManager(own=False)
+        manager2.connect()
+
+        assert manager is not manager2
+        assert manager._Listener is manager2._Listener
+
+        lock2 = manager2.get_lock("my_lock")
+        lock2.acquire(timeout=TIMEOUT)
+
+
+def test_mutex_equivalence():
+    a = Mutex()
+    b = Mutex()
+
+    assert a is not b
+    assert a != b
+
+    c = Mutex(lock=a)
+    assert c is not a
+    assert c == a
+
+    d = Mutex(lock=a.get_mutex())
+    assert d is not a
+    assert d == a
+
+
+def test_mutex_equivalence_by_proxy():
+    with SharedMemoryManager() as manager:
+        a = manager.Mutex()
+        assert isinstance(a, Mutex.Proxy)
+        b = manager.Mutex()
+
+        assert a is not b
+        assert a != b
+
+        c = copy.copy(a)
+        assert isinstance(c, Mutex.Proxy)
+
+        assert c is not a
+        assert a.get_mutex_id() == c.get_mutex_id()
+        assert a.__eq__(c)
+        assert c == a
+        assert a == c
+
+        d = manager.Mutex(lock=a)
+        assert d == a
+
+
+def client_barrier(parties, flag):
     manager = SharedMemoryManager()
     manager.connect()
-    name = f"test_barrier_{sleep}" if name_mangle else "test_barrier"
-    barrier = manager.get_barrier(name, parties)
-    t0 = time.time()
-    time.sleep(sleep)
-    barrier.wait(timeout=TIMEOUT)  # NOTE: The barrier release order is not guaranteed.
-    a_list.append(np.rint(time.time() - t0))
+    assert flag.get() == 2
+    barrier1 = manager.get_barrier("initial flag", parties)
+    barrier1.wait()
+    barrier2 = manager.get_barrier("flag set", parties)
+    barrier2.wait()
+    assert flag.get() == 3
 
 
 def test_single_barrier():
     with SharedMemoryManager() as manager:
-        a_list = manager.list()
+        flag = manager.Value(int, 2)
 
-        clients = [Process(target=client_barrier, args=(6, 3, a_list)),
-                   Process(target=client_barrier, args=(0, 3, a_list)),
-                   Process(target=client_barrier, args=(0, 3, a_list))]
+        parties = 4
+        barrier1 = manager.get_barrier("initial flag", parties, timeout=TIMEOUT)
 
-        for client in clients:
-            client.start()
+        barrier2 = manager.get_barrier("flag set", parties, timeout=TIMEOUT)
 
-        for client in clients:
-            client.join()
-
-        # We Expect to see that the timer wrapping the sleep and the barrier for each client to be that of the longest.
-        assert a_list._getvalue() == [6, 6, 6], a_list._getvalue()
-
-
-def test_multiple_barriers():
-    with SharedMemoryManager() as manager:
-        a_list = manager.list()
-
-        clients = [Process(target=client_barrier, args=(6, 1, a_list, True)),
-                   Process(target=client_barrier, args=(0, 1, a_list, True)),
-                   Process(target=client_barrier, args=(0, 1, a_list, True))]
+        clients = [Process(target=client_barrier, args=(parties, flag)),
+                   Process(target=client_barrier, args=(parties, flag)),
+                   Process(target=client_barrier, args=(parties, flag))]
+        assert len(clients) == parties - 1
 
         for client in clients:
             client.start()
 
+        barrier1.wait()  # The reason events exits...
+        flag.set(3)
+        barrier2.wait()  # NOTE: The barrier release order is not guaranteed.
+
         for client in clients:
             client.join()
-
-        # We Expect to see that the timer wrapping the sleep and the barrier for each client to be that of their sleep.
-        assert a_list._getvalue() == [0, 0, 6], a_list._getvalue()
 
 
 def test_broken_barrier():
     with SharedMemoryManager() as manager:
-        a_list = manager.list()
+        flag = manager.Value(int, 2)
 
-        # More parties than process will cause barrier.wait() to timeout.
-        client = Process(target=client_barrier, args=(6, 3, a_list))
+        # More parties than processes/threads will cause barrier.wait() to timeout.
+        client = Process(target=client_barrier, args=(2, flag))
         client.start()
         with pytest.raises(BrokenBarrierError):
             client.join()
+
+
+def multiple_client_connections():
+    manager = SharedMemoryManager()
+    manager.connect()
+    pid = manager.getpid()
+
+    manager2 = SharedMemoryManager()
+    manager2.connect()
+    pid2 = manager2.getpid()
+    assert pid == pid2
+
+    # Check that the 1st manager's connection still works.
+    assert pid == manager.getpid()
+    assert manager.getpid() == manager2.getpid()
+
+
+def test_multiple_client_connections_from_same_proc():
+    with SharedMemoryManager() as manager:
+        client = Process(target=multiple_client_connections)
+        client.start()
+        client.join()
+
+
+def concurrent_client_connections(parties):
+    manager = SharedMemoryManager()
+    manager.connect()
+
+    barrier = manager.get_barrier("this barrier", parties)
+    barrier.wait()
+    time.sleep(1)
+    barrier.wait()
+
+
+def test_multiple_client_connections_from_concurrent_procs():
+    with SharedMemoryManager() as manager:
+        n_clients = 10
+        clients = [Process(target=concurrent_client_connections, args=(n_clients,)) for x in range(n_clients)]
+
+        for client in clients:
+            client.start()
+
+        for client in clients:
+            client.join()
+
+
+def test_conn_from_same_as_start():
+    with SharedMemoryManager() as manager:
+        manager.connect()
+
+
+def test_is_server_process():
+
+    def assert_is_server_process(server_pid):
+        assert os.getpid() == server_pid
+        assert SharedMemoryManager.is_a_server_process
+
+    SharedMemoryManager.register("assert_is_server_process", callable=assert_is_server_process)
+
+    assert not SharedMemoryManager.is_a_server_process
+
+    with SharedMemoryManager() as manager:
+        assert not SharedMemoryManager.is_a_server_process
+        server_pid = manager.getpid()
+        assert os.getpid != server_pid
+        manager.assert_is_server_process(server_pid)
+
+
+def test_AutoProxy_build_cache():
+    pass
+
+
+def test_a():
+    import catkit.multiprocessing
+
+    def run():
+        import catkit.multiprocessing
+        assert SharedMemoryManager.is_a_server_process != "ljbi"
+        assert SharedMemoryManager.is_a_server_process is False
+        assert catkit.multiprocessing.DEFAULT_TIMEOUT != 100
+        assert catkit.multiprocessing.DEFAULT_TIMEOUT == 60
+
+    SharedMemoryManager.is_a_server_process = "ljbi"
+
+    catkit.multiprocessing.DEFAULT_TIMEOUT = 100
+
+    cli = Process(target=run)
+    cli.start()
+    cli.join()
+
+
+class Foo:
+    @property
+    def position(self):
+        return "this is a property"
+
+
+SharedMemoryManager.register("Foo", callable=Foo, proxytype=NamespaceProxy, create_method=True)
+
+
+def test_remote_property():
+    with SharedMemoryManager() as manager:
+        obj = manager.Foo()
+        assert isinstance(obj, BaseProxy)
+        assert obj.position == "this is a property"
+
+
+class InstrumentWithProperty(SimNPointLC400):
+    @property
+    def position(self):
+        return "this is a property"
+
+
+SharedMemoryManager.register("InstrumentWithProperty", callable=InstrumentWithProperty, proxytype=InstrumentWithProperty.Proxy, create_method=True)
+
+
+def test_instrument_property():
+    with SharedMemoryManager() as manager:
+        obj = manager.InstrumentWithProperty(config_id="npoint_tiptilt_lc_400", com_id="dummy", timeout=TIMEOUT)
+        assert isinstance(obj, BaseProxy)
+        assert obj.position == "this is a property"

--- a/catkit/tests/test_multiprocessing.py
+++ b/catkit/tests/test_multiprocessing.py
@@ -1,6 +1,6 @@
 import copy
 import os
-from threading import BrokenBarrierError, Thread
+from threading import BrokenBarrierError
 import time
 
 from multiprocess.context import AuthenticationError, TimeoutError

--- a/catkit/tests/test_multiprocessing.py
+++ b/catkit/tests/test_multiprocessing.py
@@ -14,6 +14,8 @@ from catkit.emulators.npoint_tiptilt import SimNPointLC400
 from catkit.interfaces.Instrument import Instrument, InstrumentBaseProxy
 from catkit.multiprocessing import Mutex, Process, SharedMemoryManager
 
+CI = os.environ.get('CI') in ('True', 'true')
+
 TIMEOUT = 5  # Use a shorter timeout for testing.
 
 
@@ -386,6 +388,7 @@ SharedMemoryManager.register("FastDummyInstProxy", proxytype=DummyInst.WaferThin
 
 # shape, limit = (712, 712), 50  # Image.
 # shape, limit = ((34, 34, 2)), 900  # Double Boston Dm command.
+@pytest.mark.skipif(CI, reason="Perf tests")
 @pytest.mark.parametrize(("shape", "limit"), (((712, 712), 50), ((34, 34, 2), 900)))
 def test_Mbps(shape, limit):
     with SharedMemoryManager(address=("127.0.0.1", 6060)) as manager:


### PR DESCRIPTION
Upstream PR for https://github.com/spacetelescope/hicat-package/pull/607.

See catkit/testbed/README.md


## Changes to existing key features:

 * Infrastructure code has been factored out of ``Experiment`` into ``catkit.testbed.experiment.Testbed``. This is mainly just the safety tests, however, the hicat derivation will also include ownership of all of the remote servers, i.e., the exception-handler, all device servers, the testbed state server, and the sim server.
 * ``Experiment.start()`` (that on the parent process) doesn't run the safety checks, these are now run on a child process by ``Experiment.Testbed``.
 * Synchronization between processes, especially for halting upon a safety exception, is now implemented using events.
  *  For concurrency to work, nothing should ideally be run on the parent process such that a call to ``Experiment.start()`` doesn't block the start of another experiment.
 * ``Experiment.start()`` doesn't wait and block until the experiment completes, it returns just as ``Process.start()`` does.
 * ``Experiment.join()`` has been added and mimics ``Process.join()``.
 * ``Experiment.run_experiment()`` (that run on the child process) monitors synchronization events from a dedicated monitor thread. This monitor thread will interrupt the main thread (that running ``Experiment.experiment()``) upon certain events.
* The outer script pattern is now:
```python
with Testbed():
  experiment.start()
  experiment.join()
```
* For concurrent usage, the out script pattern is now:
```python
with Testbed():
  with experiment1:
    with experiment2:
      pass  # experment2.join() will then be called.
```
* In the case that the desired start and wait/join order prevents the use of nested context managers,  multiple try-finally blocks must be implemented such that all joins are executed in the correct ``finally`` statement.

