### PR TITLE
remove codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-* @jamienoss
-/catkit/hardware/iris_ao/ @kjbrooks @jamienoss


### PR DESCRIPTION
@jamienoss and @kjbrooks have left the institute and are still overall code-owners for the entire repo and iris-ao respectively. 

This PR is removing the code-owners file to avoid any delays because of that. 