### PR TITLE
added function to allow irisao command to be plotted in a subplot of …

### DIFF
--- a/catkit/hardware/iris_ao/segmented_dm_command.py
+++ b/catkit/hardware/iris_ao/segmented_dm_command.py
@@ -417,6 +417,39 @@ class SegmentedDmCommand(object):
             plt.close()
         else:
             plt.show()
+    
+    def get_wavefront_custom(self):#,figure_name_prefix, out_dir, vmax=0.5e-6*u.meter, save_figure=True):
+        """
+        Plot the deployed mirror state (wavefront error)
+
+        :param figure_name_prefix: str, String to be added to filenames of output figures
+        :param out_dir: str, name of output directory
+        :param vmax: astropy unit quantity, the maximum value to display in the plot (as expected
+                     by Poppy)
+        :param save_figure: bool, If true, save out the figures in the directory specified by
+                            out_dir
+        """
+        display_data = set_to_dm_limits(self.data)
+        # Convert the PTT list from DM to Poppy units
+        converted_list = convert_ptt_units(display_data, tip_factor=1, tilt_factor=-1,
+                                           starting_units=self.dm_command_units,
+                                           ending_units=(u.m, u.rad, u.rad))
+        # We want to round to four significant digits when in DM units (um, mrad, mrad).
+        # Here, we are in SI units (m, rad, rad), so we round to the equivalent, 10 decimals.
+        rounded_list = round_ptt_list(converted_list, decimals=10)
+        for seg, values in zip(self.aperture.segmentlist, rounded_list):
+            self.aperture.set_actuator(seg, values[0], values[1], values[2])
+        
+        #self.aperture.get_opd(wavelength) , .sample?
+        # ax.set_title('WFE')    
+        # self.aperture.display(what='opd', title='',
+        #                       opd_vmax=vmax,ax=ax)
+        # if save_figure:
+        #     plt.savefig(os.path.join(out_dir, f'{figure_name_prefix}wfe_on_dm.png'))
+        #     plt.close()
+        # else:
+        #     plt.show()  
+        # return ax          
 
     @poppy.utils.quantity_input(display_wavelength=u.nm)   # decorator provides a check on input units
     def plot_psf(self, wavelength=640*u.nm, figure_name_prefix=None, rotation_angle=0,  out_dir=None, vmin=1e-8,

--- a/catkit/hardware/iris_ao/segmented_dm_command.py
+++ b/catkit/hardware/iris_ao/segmented_dm_command.py
@@ -377,19 +377,10 @@ class SegmentedDmCommand(object):
         :param save_figures: bool, If true, save out the figures in the directory specified
                              by out_dir
         """
-        # Grab the units of the DM for the piston, tip, tilt values and check that
-        #  they don't exceed the DM hardware limits
-        display_data = set_to_dm_limits(self.data)
-        # Convert the PTT list from DM to Poppy units
-        converted_list = convert_ptt_units(display_data, tip_factor=1, tilt_factor=-1,
-                                           starting_units=self.dm_command_units,
-                                           ending_units=(u.m, u.rad, u.rad))
-        # We want to round to four significant digits when in DM units (um, mrad, mrad).
-        # Here, we are in SI units (m, rad, rad), so we round to the equivalent, 10 decimals.
-        rounded_list = round_ptt_list(converted_list, decimals=10)
-        for seg, values in zip(self.aperture.segmentlist, rounded_list):
-            self.aperture.set_actuator(seg, values[0], values[1], values[2])
-
+        # update opd on mirror
+        self.get_wavefront_custom()
+        
+        # make figure
         if figure_name_prefix:
             figure_name_prefix = f'{figure_name_prefix}_'
         if display_wavefront:

--- a/catkit/hardware/iris_ao/segmented_dm_command.py
+++ b/catkit/hardware/iris_ao/segmented_dm_command.py
@@ -418,16 +418,15 @@ class SegmentedDmCommand(object):
         else:
             plt.show()
     
-    def get_wavefront_custom(self):#,figure_name_prefix, out_dir, vmax=0.5e-6*u.meter, save_figure=True):
+    def get_wavefront_custom(self):
         """
-        Plot the deployed mirror state (wavefront error)
-
-        :param figure_name_prefix: str, String to be added to filenames of output figures
-        :param out_dir: str, name of output directory
-        :param vmax: astropy unit quantity, the maximum value to display in the plot (as expected
-                     by Poppy)
-        :param save_figure: bool, If true, save out the figures in the directory specified by
-                            out_dir
+        Get the deployed mirror state (wavefront error)
+        To make plot:
+        total_iris = iris_ao.HicatSegmentedDmCommand()
+        total_iris.read_initial_command([tuple(row) for row in command_to_plot])
+        total_iris.get_wavefront_custom()
+        command = total_iris.aperture.sample(what='opd') 
+        image = ax.matshow(command)
         """
         display_data = set_to_dm_limits(self.data)
         # Convert the PTT list from DM to Poppy units
@@ -439,17 +438,7 @@ class SegmentedDmCommand(object):
         rounded_list = round_ptt_list(converted_list, decimals=10)
         for seg, values in zip(self.aperture.segmentlist, rounded_list):
             self.aperture.set_actuator(seg, values[0], values[1], values[2])
-        
-        #self.aperture.get_opd(wavelength) , .sample?
-        # ax.set_title('WFE')    
-        # self.aperture.display(what='opd', title='',
-        #                       opd_vmax=vmax,ax=ax)
-        # if save_figure:
-        #     plt.savefig(os.path.join(out_dir, f'{figure_name_prefix}wfe_on_dm.png'))
-        #     plt.close()
-        # else:
-        #     plt.show()  
-        # return ax          
+              
 
     @poppy.utils.quantity_input(display_wavelength=u.nm)   # decorator provides a check on input units
     def plot_psf(self, wavelength=640*u.nm, figure_name_prefix=None, rotation_angle=0,  out_dir=None, vmin=1e-8,

--- a/catkit/hardware/iris_ao/segmented_dm_command.py
+++ b/catkit/hardware/iris_ao/segmented_dm_command.py
@@ -378,7 +378,7 @@ class SegmentedDmCommand(object):
                              by out_dir
         """
         # update opd on mirror
-        self.get_wavefront_custom()
+        self.apply_current_wavefront()
         
         # make figure
         if figure_name_prefix:
@@ -409,13 +409,13 @@ class SegmentedDmCommand(object):
         else:
             plt.show()
     
-    def get_wavefront_custom(self):
+    def apply_current_wavefront(self):
         """
         Get the deployed mirror state (wavefront error)
         To make plot:
         total_iris = iris_ao.HicatSegmentedDmCommand()
         total_iris.read_initial_command([tuple(row) for row in command_to_plot])
-        total_iris.get_wavefront_custom()
+        total_iris.apply_current_wavefront()
         command = total_iris.aperture.sample(what='opd') 
         image = ax.matshow(command)
         """


### PR DESCRIPTION
https://jira.stsci.edu/browse/CATKIT-103

currently it is very difficult to plot an irisao command, this function facilitates that.  it does posses some re-used code from `display()`: so maybe we can make that cleaner by having `display()` call `get_wavefront_custom()`?